### PR TITLE
Add stopAtFileSystemBoundary

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -228,11 +228,19 @@ public class GitCommitIdMojo extends AbstractMojo {
   private boolean failOnUnableToExtractRepoInfo;
 
   /**
+   * If true, plugin will fallback to searching for .git directory recursively until file
+   * system boundary is hit.
+   *
+   * @parameter expression="${git.stopAtFileSystemBoundary}" default-value="false"
+   */
+  private boolean stopAtFileSystemBoundary;
+
+  /**
    * The properties we store our data in and then expose them
    */
   private Properties properties;
 
-  public final String logPrefix = "[GitCommitIdMojo] ";
+  public static final String logPrefix = "[GitCommitIdMojo] ";
 
   boolean runningTests = false;
 
@@ -243,10 +251,10 @@ public class GitCommitIdMojo extends AbstractMojo {
   LoggerBridge verboseLoggerBridge = new MavenLoggerBridge(getLog(), true);
 
   public void execute() throws MojoExecutionException {
-	// Set the verbose setting now it should be correctly loaded from maven. 
-	loggerBridge.setVerbose(verbose);
-	alwaysLog("Verbose Setting: " + Boolean.valueOf(verbose));
-	  
+    // Set the verbose setting now it should be correctly loaded from maven.
+    loggerBridge.setVerbose(verbose);
+    alwaysLog("Verbose Setting: " + Boolean.valueOf(verbose));
+
     if (isPomProject(project) && skipPoms) {
       alwaysLog("Skipping the execution as it is a project with packaging type: 'pom'");
       return;
@@ -328,7 +336,9 @@ public class GitCommitIdMojo extends AbstractMojo {
    * @return the File representation of the .git directory
    */
   private File lookupGitDirectory() throws MojoExecutionException {
-    return new GitDirLocator(project, reactorProjects).lookupGitDirectory(dotGitDirectory);
+    File file = new GitDirLocator(project, reactorProjects, loggerBridge, stopAtFileSystemBoundary).lookupGitDirectory(dotGitDirectory);
+    log("Using git directory %s", file == null ? null : file.getAbsolutePath());
+    return file;
   }
 
   private Properties initProperties() throws MojoExecutionException {

--- a/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
+++ b/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import pl.project13.maven.git.log.LoggerBridge;
 
 import java.io.File;
 import java.util.Collections;
@@ -36,6 +37,9 @@ public class GitDirLocatorTest {
   @Mock
   MavenProject project;
 
+  @Mock
+  LoggerBridge loggerBridge;
+
   List<MavenProject> reactorProjects = Collections.emptyList();
 
   @Test
@@ -44,7 +48,7 @@ public class GitDirLocatorTest {
     File dotGitDir = Files.createTempDir();
 
     // when
-    GitDirLocator locator = new GitDirLocator(project, reactorProjects);
+    GitDirLocator locator = new GitDirLocator(project, reactorProjects, loggerBridge, false);
     File foundDirectory = locator.lookupGitDirectory(dotGitDir);
 
     // then


### PR DESCRIPTION
I would like the plugin to search parent directory (if everything else fails) and search for .git file/folder or until root folder is found. I've added stopAtFileSystemBoundary property to turn on this behaviour.
Also I found a bug in resolving submodule - relative path should be constructed using .git file's parent folder.
I added more logging.
Submodules are resolved also when .git was not specified manually.
Manually configured directory should not trigger searching even if it does not exists - makes debugging hard.
No new automated tests though :(