### PR TITLE
Fix differences in the output of native and jgit

### DIFF
--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -142,13 +142,13 @@ public class JGitProvider extends GitDataProvider {
   @Override
   protected String getCommitMessageFull() {
     String fullMessage = headCommit.getFullMessage();
-    return fullMessage;
+    return fullMessage.trim();
   }
 
   @Override
   protected String getCommitMessageShort() {
     String shortMessage = headCommit.getShortMessage();
-    return shortMessage;
+    return shortMessage.trim();
   }
 
   @Override

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -3,8 +3,10 @@ package pl.project13.maven.git;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -18,6 +20,7 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.jetbrains.annotations.NotNull;
+
 import pl.project13.jgit.DescribeCommand;
 import pl.project13.jgit.DescribeResult;
 import pl.project13.maven.git.log.LoggerBridge;
@@ -66,13 +69,13 @@ public class JGitProvider extends GitDataProvider {
   @Override
   protected String getBuildAuthorName() {
     String userName = git.getConfig().getString("user", null, "name");
-    return userName;
+    return Objects.firstNonNull(userName, "");
   }
 
   @Override
   protected String getBuildAuthorEmail() {
     String userEmail = git.getConfig().getString("user", null, "email");
-    return userEmail;
+    return Objects.firstNonNull(userEmail, "");
   }
 
   @Override

--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -55,26 +55,26 @@ public class NativeGitProvider extends GitDataProvider {
 
   @Override
   protected String getBuildAuthorName() {
-      try {
-          return runGitCommand(canonical, "config --get user.name");
-      } catch (NativeCommandException e) {
-          if (e.getExitCode() == 1) { // No config file found
-              return "";
-          }
-          throw Throwables.propagate(e);
+    try {
+      return runGitCommand(canonical, "config --get user.name");
+    } catch (NativeCommandException e) {
+      if (e.getExitCode() == 1) { // No config file found
+        return "";
       }
+      throw Throwables.propagate(e);
+    }
   }
 
   @Override
   protected String getBuildAuthorEmail() {
-      try {
-          return runGitCommand(canonical, "config --get user.email");
-      } catch (NativeCommandException e) {
-          if (e.getExitCode() == 1) { // No config file found
-              return "";
-          }
-          throw Throwables.propagate(e);
+    try {
+      return runGitCommand(canonical, "config --get user.email");
+    } catch (NativeCommandException e) {
+      if (e.getExitCode() == 1) { // No config file found
+        return "";
       }
+      throw Throwables.propagate(e);
+    }
   }
 
   @Override
@@ -94,13 +94,13 @@ public class NativeGitProvider extends GitDataProvider {
         branch = branch.replace("refs/heads/", "");
       }
     } catch(NativeCommandException e) {
-        // it seems that git repro is in 'DETACHED HEAD'-State, using Commid-Id as Branch
-        String err = e.getStderr();
-        if (err != null && err.contains("ref HEAD is not a symbolic ref")) {
-            branch = getCommitId();
-        } else {
-            throw Throwables.propagate(e);
-        }
+      // it seems that git repro is in 'DETACHED HEAD'-State, using Commid-Id as Branch
+      String err = e.getStderr();
+      if (err != null && err.contains("ref HEAD is not a symbolic ref")) {
+        branch = getCommitId();
+      } else {
+        throw Throwables.propagate(e);
+      }
     }
     return branch;
   }
@@ -215,15 +215,15 @@ public class NativeGitProvider extends GitDataProvider {
 
     // welcome to text output parsing hell! - no `\n` is not enough
     for (String line : Splitter.onPattern("\\((fetch|push)\\)?").split(remotes)) {
-        String trimmed = line.trim();
+      String trimmed = line.trim();
 
-        if (trimmed.startsWith("origin")) {
-            String[] splited = trimmed.split("\\s+");
-            if (splited.length != REMOTE_COLS - 1) { // because (fetch/push) was trimmed
-                throw new MojoExecutionException("Unsupported GIT output (verbose remote address): " + line);
-            }
-            remoteUrl = splited[1];
+      if (trimmed.startsWith("origin")) {
+        String[] splited = trimmed.split("\\s+");
+        if (splited.length != REMOTE_COLS - 1) { // because (fetch/push) was trimmed
+          throw new MojoExecutionException("Unsupported GIT output (verbose remote address): " + line);
         }
+        remoteUrl = splited[1];
+      }
     }
     return remoteUrl;
   }
@@ -250,31 +250,30 @@ public class NativeGitProvider extends GitDataProvider {
   }
 
   private String runQuietGitCommand(File directory, String gitCommand) {
-      final String env = System.getenv("GIT_PATH");
-      final String exec = (env == null) ? "git" : env;
-      final String command = String.format("%s %s", exec, gitCommand);
+    final String env = System.getenv("GIT_PATH");
+    final String exec = (env == null) ? "git" : env;
+    final String command = String.format("%s %s", exec, gitCommand);
 
-      try {
-          return getRunner().run(directory, command.trim()).trim();
-      } catch (IOException e) {
-          throw Throwables.propagate(e);
-      }
+    try {
+      return getRunner().run(directory, command.trim()).trim();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   private String runGitCommand(File directory, String gitCommand) throws NativeCommandException {
-      final String env = System.getenv("GIT_PATH");
-      final String exec = (env == null) ? "git" : env;
-      final String command = String.format("%s %s", exec, gitCommand);
+    final String env = System.getenv("GIT_PATH");
+    final String exec = (env == null) ? "git" : env;
+    final String command = String.format("%s %s", exec, gitCommand);
 
-      try {
-          return getRunner().run(directory, command.trim()).trim();
-      } catch (NativeCommandException e) {
-          throw e;
-      } catch (IOException e) {
-          throw Throwables.propagate(e);
-      }
+    try {
+      return getRunner().run(directory, command.trim()).trim();
+    } catch (NativeCommandException e) {
+      throw e;
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
-
 
   private ProcessRunner getRunner() {
     if (runner == null) {
@@ -292,48 +291,48 @@ public class NativeGitProvider extends GitDataProvider {
 
   public static class NativeCommandException extends IOException
   {
-      private final int exitCode;
-      private final String command;
-      private final File directory;
-      private final String stdout;
-      private final String stderr;
+    private final int exitCode;
+    private final String command;
+    private final File directory;
+    private final String stdout;
+    private final String stderr;
 
-      public NativeCommandException(int exitCode,
-                                    String command,
-                                    File directory,
-                                    String stdout,
-                                    String stderr) {
-          this.exitCode = exitCode;
-          this.command = command;
-          this.directory = directory;
-          this.stdout = stdout;
-          this.stderr = stderr;
-      }
+    public NativeCommandException(int exitCode,
+                                  String command,
+                                  File directory,
+                                  String stdout,
+                                  String stderr) {
+      this.exitCode = exitCode;
+      this.command = command;
+      this.directory = directory;
+      this.stdout = stdout;
+      this.stderr = stderr;
+    }
 
-      public int getExitCode() {
-          return exitCode;
-      }
+    public int getExitCode() {
+      return exitCode;
+    }
 
-      public String getCommand() {
-          return command;
-      }
+    public String getCommand() {
+      return command;
+    }
 
-      public File getDirectory() {
-          return directory;
-      }
+    public File getDirectory() {
+      return directory;
+    }
 
-      public String getStdout() {
-          return stdout;
-      }
+    public String getStdout() {
+      return stdout;
+    }
 
-      public String getStderr() {
-          return stderr;
-      }
+    public String getStderr() {
+      return stderr;
+    }
 
-      @Override
-      public String getMessage() {
-          return format("Git command exited with invalid status [%d]: stdout: `%s`, stderr: `%s`", exitCode, stdout, stderr);
-      }
+    @Override
+    public String getMessage() {
+      return format("Git command exited with invalid status [%d]: stdout: `%s`, stderr: `%s`", exitCode, stdout, stderr);
+    }
   }
 
   protected static class JavaProcessRunner implements ProcessRunner {

--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -1,5 +1,7 @@
 package pl.project13.maven.git;
 
+import static java.lang.String.format;
+
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -93,10 +95,12 @@ public class NativeGitProvider extends GitDataProvider {
       }
     } catch(NativeCommandException e) {
         // it seems that git repro is in 'DETACHED HEAD'-State, using Commid-Id as Branch
-        if (e.getExitCode() == 1) {
+        String err = e.getStderr();
+        if (err != null && err.contains("ref HEAD is not a symbolic ref")) {
             branch = getCommitId();
+        } else {
+            throw Throwables.propagate(e);
         }
-        throw Throwables.propagate(e);
     }
     return branch;
   }
@@ -291,12 +295,19 @@ public class NativeGitProvider extends GitDataProvider {
       private final int exitCode;
       private final String command;
       private final File directory;
+      private final String stdout;
+      private final String stderr;
 
-      public NativeCommandException(int exitCode, String command, File directory, String message) {
-          super(message);
+      public NativeCommandException(int exitCode,
+                                    String command,
+                                    File directory,
+                                    String stdout,
+                                    String stderr) {
           this.exitCode = exitCode;
           this.command = command;
           this.directory = directory;
+          this.stdout = stdout;
+          this.stderr = stderr;
       }
 
       public int getExitCode() {
@@ -309,6 +320,19 @@ public class NativeGitProvider extends GitDataProvider {
 
       public File getDirectory() {
           return directory;
+      }
+
+      public String getStdout() {
+          return stdout;
+      }
+
+      public String getStderr() {
+          return stderr;
+      }
+
+      @Override
+      public String getMessage() {
+          return format("Git command exited with invalid status [%d]: stdout: `%s`, stderr: `%s`", exitCode, stdout, stderr);
       }
   }
 
@@ -332,9 +356,7 @@ public class NativeGitProvider extends GitDataProvider {
 
             if (proc.exitValue() != 0) {
               final StringBuilder errMsg = readStderr(err);
-
-              final String message = String.format("Git command exited with invalid status [%d]: stdout: `%s`, stderr: `%s`", proc.exitValue(), output, errMsg.toString());
-              throw new NativeCommandException(proc.exitValue(), command, directory, message);
+              throw new NativeCommandException(proc.exitValue(), command, directory, output, errMsg.toString());
             }
             output = commandResult.toString();
           } catch (InterruptedException ex) {

--- a/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
+++ b/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
@@ -25,6 +25,8 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 
+import com.google.common.io.Files;
+
 /**
  * Quick and dirty maven projects tree structure to create on disk during integration tests
  * Can have both parent and child projects set up
@@ -118,7 +120,14 @@ public class FileSystemMavenSandbox {
 
   private void createGitRepoIfRequired() throws IOException {
     if (gitRepoTargetDir != null) {
-      FileUtils.copyDirectory(gitRepoSourceDir, new File(gitRepoTargetDir, ".git"));
+      File gitFolder = new File(gitRepoTargetDir, ".git");
+      FileUtils.copyDirectory(gitRepoSourceDir, gitFolder);
+      // As the WITH_NO_CHANGES and WITH_CHANGES git trees contain empty
+      // folders whose existence is crucial for the native git to run (jgit does not mind)
+      // *and* because empty folders are silently omitted from git checkins, ensure that
+      // these folders exist
+      Files.createParentDirs(new File(gitFolder, "refs/heads"));
+      Files.createParentDirs(new File(gitFolder, "refs/tags"));
     }
   }
 

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -622,17 +622,17 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void runGitDescribeWithMatchOption(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox.withParentProject("my-pom-project", "pom")
-                .withChildProject("my-jar-module", "jar")
-                .withGitRepoInChild(AvailableGitTestRepo.MAVEN_GIT_COMMIT_ID_PLUGIN)
+    mavenSandbox.withParentProject("my-plugin-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.MAVEN_GIT_COMMIT_ID_PLUGIN)
                 .create(CleanUp.CLEANUP_FIRST);
-    MavenProject targetProject = mavenSandbox.getChildProject();
+    MavenProject targetProject = mavenSandbox.getParentProject();
 
     setProjectToExecuteMojoIn(targetProject);
 
     Map<String,String> gitTagMap = new HashMap<String,String>();
-    gitTagMap.put("v2.1.8", "4f787aa37d5d9c06780278f0cf92553d304820a2");
-    gitTagMap.put("v2.1.9", "a9dba4a25b64ab288d90cd503785b830d2e189a2");
+    gitTagMap.put("v2.1.11", "56c5a491720ce35ae8f8626be1d3414728f1b953");
+    gitTagMap.put("v2.1.12", "e9879658209ee81d7bf50ceedd028737f0b1cd0c");
 
     for (Map.Entry<String,String> entry : gitTagMap.entrySet()) {
       String gitDescribeMatchNeedle = entry.getKey();

--- a/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
@@ -1,0 +1,152 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.project13.maven.git;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.internal.util.reflection.Whitebox.setInternalState;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Properties;
+
+import org.apache.maven.project.MavenProject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import pl.project13.maven.git.FileSystemMavenSandbox.CleanUp;
+
+public class NativeAndJGitProviderTest extends GitIntegrationTest
+{
+    public static final String[] GIT_KEYS = new String[] {
+                    "git.build.time",
+                    "git.branch",
+                    "git.commit.id",
+                    "git.commit.id.abbrev",
+                    "git.commit.id.describe",
+                    "git.build.user.name",
+                    "git.build.user.email",
+                    "git.commit.user.name",
+                    "git.commit.user.email",
+                    "git.commit.message.full",
+                    "git.commit.message.short",
+                    "git.commit.time",
+                    "git.remote.origin.url"
+    };
+
+    // Can't be static, not thread safe.
+    public final DateFormat DEFAULT_FORMAT = new SimpleDateFormat("dd.MM.yyyy '@' HH:mm:ss z");
+
+    @Test
+    public void testCompareBasic() throws Exception
+    {
+        // Test on all available basic repos to ensure that the output is identical.
+        for (AvailableGitTestRepo testRepo : AvailableGitTestRepo.values()) {
+            mavenSandbox.withParentProject("my-basic-project", "jar").withNoChildProject().withGitRepoInParent(testRepo).create(CleanUp.CLEANUP_FIRST);
+            MavenProject targetProject = mavenSandbox.getParentProject();
+            verifyNativeAndJGit(targetProject, DEFAULT_FORMAT);
+        }
+    }
+
+    @Test
+    public void testCompareSubrepoInRoot() throws Exception
+    {
+        for (AvailableGitTestRepo testRepo : AvailableGitTestRepo.values()) {
+            if (testRepo == AvailableGitTestRepo.MAVEN_GIT_COMMIT_ID_PLUGIN) {
+                continue; // Don't create a subrepo based off the plugin repo itself.
+            }
+            mavenSandbox.withParentProject("my-pom-project", "pom").withChildProject("my-jar-module", "jar").withGitRepoInParent(testRepo).create(CleanUp.CLEANUP_FIRST);
+            MavenProject targetProject = mavenSandbox.getParentProject();
+            verifyNativeAndJGit(targetProject, DEFAULT_FORMAT);
+        }
+    }
+
+    @Test
+    public void testCompareSubrepoInChild() throws Exception
+    {
+        for (AvailableGitTestRepo testRepo : AvailableGitTestRepo.values()) {
+            if (testRepo == AvailableGitTestRepo.MAVEN_GIT_COMMIT_ID_PLUGIN) {
+                continue; // Don't create a subrepo based off the plugin repo itself.
+            }
+            mavenSandbox.withParentProject("my-pom-project", "pom").withChildProject("my-jar-module", "jar").withGitRepoInParent(testRepo).create(CleanUp.CLEANUP_FIRST);
+            MavenProject targetProject = mavenSandbox.getChildProject();
+            verifyNativeAndJGit(targetProject, DEFAULT_FORMAT);
+        }
+    }
+
+
+    private void verifyNativeAndJGit(MavenProject targetProject, DateFormat format) throws Exception
+    {
+        setProjectToExecuteMojoIn(targetProject);
+
+        alterMojoSettings("useNativeGit", false);
+        alterMojoSettings("skipPoms", false);
+        mojo.execute();
+        Properties jgitProps = createCopy(targetProject.getProperties());
+
+        alterMojoSettings("useNativeGit", true);
+        mojo.execute();
+        Properties nativeProps = createCopy(targetProject.getProperties());
+
+        assertGitPropertiesPresentInProject(jgitProps);
+        assertGitPropertiesPresentInProject(nativeProps);
+
+        for (String key : GIT_KEYS) {
+            if (!key.equals("git.build.time")) { // git.build.time is excused because the two runs happened at different times.
+                assertEquals("Key difference for key: '" + key + "'", jgitProps.getProperty(key), nativeProps.getProperty(key));
+            }
+            else {
+                // Ensure that the date formats are parseable and within reason. If running all the git commands on the
+                // native provider takes more than 60 seconds, then something is seriously wrong.
+                long jGitBuildTimeInMs = format.parse(jgitProps.getProperty(key)).getTime();
+                long nativeBuildTimeInMs = format.parse(nativeProps.getProperty(key)).getTime();
+                Assert.assertTrue("Time ran backwards, jgitTime after nativeTime!", jGitBuildTimeInMs <= nativeBuildTimeInMs);
+                Assert.assertTrue("Build ran too slow.", (nativeBuildTimeInMs - jGitBuildTimeInMs) < 60000L); // If native takes more than 1 minute, something is wrong.
+            }
+        }
+
+        // Check the commit time to be equal in ms, too.
+        long jGitCommitTimeInMs = format.parse(jgitProps.getProperty("git.commit.time")).getTime();
+        long nativeCommitTimeInMs = format.parse(nativeProps.getProperty("git.commit.time")).getTime();
+
+        assertEquals("commit times parse to different time stamps", jGitCommitTimeInMs, nativeCommitTimeInMs);
+    }
+
+    private void alterMojoSettings(String parameterName, Object parameterValue)
+    {
+        setInternalState(mojo, parameterName, parameterValue);
+    }
+
+    private Properties createCopy(Properties orig)
+    {
+        Properties p = new Properties();
+        for (Object o : orig.keySet()) {
+            String key = o.toString();
+            p.setProperty(key, orig.getProperty(key));
+        }
+
+        return p;
+    }
+
+    private void assertGitPropertiesPresentInProject(Properties properties)
+    {
+        for (String key : GIT_KEYS) {
+            assertThat(properties).satisfies(new ContainsKeyCondition(key));
+        }
+    }
+}

--- a/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
@@ -135,8 +135,7 @@ public class NativeAndJGitProviderTest extends GitIntegrationTest
     private Properties createCopy(Properties orig)
     {
         Properties p = new Properties();
-        for (Object o : orig.keySet()) {
-            String key = o.toString();
+        for (String key : orig.stringPropertyNames()) {
             p.setProperty(key, orig.getProperty(key));
         }
 


### PR DESCRIPTION
On my box (using git 1.9.3), for a small project, there are the
following differences between jgit and native output:

```
field                   | jgit                       | native
git.build.user.name     | Henning Schmiedehausen     | "Henning Schmiedehausen"
git.build.user.email    | henning@schmiedehausen.org | "henning@schmiedehausen.org"
git.dirty               | true                       | false
git.commit.user.name    | Henning Schmiedehausen     | "Henning Schmiedehausen"
git.commit.user.email   | henning@schmiedehausen.org | "henning@schmiedehausen.org"
git.commit.message.full | Create README.md           | "Create README.md"
git.commit.message.short| Create README.md           | "Create README.md"
git.commit.time         | 2014-11-21T18:47:34-0800   | "2014-11-21 18:47:34 -0800"
git.tags                | bar,foo                    | foo,bar,origin/master,origin/
```

This uses the following custom settings:

```xml
<configuration>
    <dateFormat>yyyy-MM-dd'T'HH:mm:ssZZ</dateFormat>
    <abbrevLength>10</abbrevLength>
    <gitDescribe>
        <always>true</always>
        <abbrev>7</abbrev>
        <dirty>-dirty</dirty>
        <forceLongFormat>false</forceLongFormat>
    </gitDescribe>
</configuration>
```

Especially the "git.dirty" and "git.tags" is catastrophic but all the
other fields also make it hard to parse *any* information across
different settings of the git provider.

This patch fixes all the differences. Now the output of jgit and
native are identical.

Not a single unit test broke with these output changes. This is
worrisome because it implies that test coverage at least for the
native provider is not good.