### PR TITLE
Update maven-plugin-api to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   </scm>
 
   <properties>
-    <maven-plugin-api.version>2.2.1</maven-plugin-api.version>
+    <maven-plugin-api.version>3.3.1</maven-plugin-api.version>
 
     <jgit.version>3.4.1.201406201815-r</jgit.version>
     <junit.version>4.12</junit.version>
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
-      <version>${maven-plugin-api.version}</version>
+      <version>2.2.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The latest version of `org.apache.maven:maven-project` is still 2.2.1, so the properties had to be split.