### PR TITLE
Avoid NPE as discussed in #57

### DIFF
--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -85,12 +85,12 @@ public class JGitProvider extends GitDataProvider {
       // more details parsed out bellow
       Ref head = git.getRef(Constants.HEAD);
       if (head == null) {
-        throw new MojoExecutionException("Could not get HEAD Ref, are you sure you've set the dotGitDirectory property of this plugin to a valid path?");
+        throw new MojoExecutionException("Could not get HEAD Ref, are you sure you have set the dotGitDirectory property of this plugin to a valid path?");
       }
       revWalk = new RevWalk(git);
       ObjectId headObjectId = head.getObjectId();
       if(headObjectId == null){
-        throw new MojoExecutionException("Could not get HEAD Ref, are you sure you've some commits in the dotGitDirectory?");
+        throw new MojoExecutionException("Could not get HEAD Ref, are you sure you have some commits in the dotGitDirectory?");
       }
       headCommit = revWalk.parseCommit(headObjectId);
       revWalk.markStart(headCommit);

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -83,12 +83,16 @@ public class JGitProvider extends GitDataProvider {
   protected void prepareGitToExtractMoreDetailedReproInformation() throws MojoExecutionException {
     try {
       // more details parsed out bellow
-      Ref HEAD = git.getRef(Constants.HEAD);
-      if (HEAD == null) {
+      Ref head = git.getRef(Constants.HEAD);
+      if (head == null) {
         throw new MojoExecutionException("Could not get HEAD Ref, are you sure you've set the dotGitDirectory property of this plugin to a valid path?");
       }
       revWalk = new RevWalk(git);
-      headCommit = revWalk.parseCommit(HEAD.getObjectId());
+      ObjectId headObjectId = head.getObjectId();
+      if(headObjectId == null){
+        throw new MojoExecutionException("Could not get HEAD Ref, are you sure you've some commits in the dotGitDirectory?");
+      }
+      headCommit = revWalk.parseCommit(headObjectId);
       revWalk.markStart(headCommit);
     } catch (MojoExecutionException e) {
       throw e;


### PR DESCRIPTION
revWalk.parseCommit will throw a NPE when Argument is null.

```
Caused by: java.lang.NullPointerException
	at org.eclipse.jgit.lib.ObjectIdOwnerMap.get(ObjectIdOwnerMap.java:131)
	at org.eclipse.jgit.revwalk.RevWalk.parseAny(RevWalk.java:838)
	at org.eclipse.jgit.revwalk.RevWalk.parseCommit(RevWalk.java:753)
	at pl.project13.maven.git.JGitProvider.prepareGitToExtractMoreDetailedReproInformation(JGitProvider.java:91)
	... 26 more
```