### PR TITLE
Introduce a demo-profile inside the pom, see #181

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ But I highly recommend using only stable versions, from maven central... :-)
 </pluginRepositories>
 ```
 
+If you just would like to see what the plugin can do, you can clone the repository and run
+```
+mvn clean install -Dmaven.test.skip=true && mvn clean package -Pdemo -Dmaven.test.skip=true
+```
+
 Using the plugin
 ----------------
 It's really simple to setup this plugin; below is a sample pom that you may base your **pom.xml** on. Note that it binds to the initialize phase by default such that all Git properties are available for use throughout the build lifecycle.

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,6 @@
     </dependency>
 
     <!-- JGit -->
-
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
@@ -188,48 +187,7 @@
     </resources>
 
     <plugins>
-      <!--<plugin>-->
-        <!--<groupId>pl.project13.maven</groupId>-->
-        <!--<artifactId>git-commit-id-plugin</artifactId>-->
-        <!--<version>${project.version}</version>-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<goals>-->
-              <!--<goal>revision</goal>-->
-            <!--</goals>-->
-          <!--</execution>-->
-        <!--</executions>-->
-        <!--<configuration>-->
-          <!--<verbose>true</verbose>-->
-          <!--<skip>false</skip>-->
-          <!--<prefix>git</prefix>-->
-          <!--<dotGitDirectory>${project.basedir}/.git</dotGitDirectory>-->
-          <!--<generateGitPropertiesFile>true</generateGitPropertiesFile>-->
-          <!--<generateGitPropertiesFilename>target/testing.properties</generateGitPropertiesFilename>-->
-
-          <!--<dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>-->
-          <!--<useNativeGit>false</useNativeGit>-->
-          <!--<abbrevLength>7</abbrevLength>-->
-          <!--<format>properties</format>-->
-
-          <!--<gitDescribe>-->
-            <!--<skip>false</skip>-->
-            <!--<always>false</always>-->
-            <!--<abbrev>7</abbrev>-->
-            <!--<match>*</match>-->
-            <!--<dirty>-DEVEL</dirty>-->
-            <!--<forceLongFormat>false</forceLongFormat>-->
-          <!--</gitDescribe>-->
-
-          <!--<excludeProperties>-->
-            <!--<excludeProperty>git.commit.*</excludeProperty>-->
-            <!--<excludeProperty>git.remote.origin.url</excludeProperty>-->
-          <!--</excludeProperties>-->
-
-          <!--<failOnNoGitDirectory>true</failOnNoGitDirectory>-->
-          <!--<failOnUnableToExtractRepoInfo>true</failOnUnableToExtractRepoInfo>-->
-        <!--</configuration>-->
-      <!--</plugin>-->
+      <!-- if you would like to run the git-commit-id-plugin for your build, you could also include it here instead using a profile (see README.md) -->
       <!-- Setting built-in java compiler properties -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -290,6 +248,51 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>demo</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <version>${project.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>revision</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <verbose>true</verbose>
+              <skip>false</skip>
+              <prefix>git</prefix>
+              <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+              <generateGitPropertiesFile>true</generateGitPropertiesFile>
+              <generateGitPropertiesFilename>target/testing.properties</generateGitPropertiesFilename>
+              <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
+              <useNativeGit>false</useNativeGit>
+              <abbrevLength>7</abbrevLength>
+              <format>properties</format>
+              <gitDescribe>
+                <skip>false</skip>
+                <always>false</always>
+                <abbrev>7</abbrev>
+                <match>*</match>
+                <dirty>-DEVEL</dirty>
+                <forceLongFormat>false</forceLongFormat>
+              </gitDescribe>
+              <excludeProperties>
+                <excludeProperty>git.commit.*</excludeProperty>
+                <excludeProperty>git.remote.origin.url</excludeProperty>
+              </excludeProperties>
+              <failOnNoGitDirectory>false</failOnNoGitDirectory>
+              <failOnUnableToExtractRepoInfo>true</failOnUnableToExtractRepoInfo>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
As suggested in https://github.com/ktoso/maven-git-commit-id-plugin/issues/181, I would like to introduce a demo-Profile where anybody can just run the plugin right away.

This would speed up to live test wheather something is broken under some conditions or not. I used this in one of my own plugins to discover some nasty bugs.

However, this will not avoid writing Testcases. This should only help to track down a problem and then writing test cases for it.
For my own plugin I once had included it in the regular-build (so run everytime for everytime), However when i screwed up, I had no chance to re run ``mvn clean install`` without removing the config of the plugin. Therefore I needed to moved it to a different profile where I could choose if I would like to run it or not.