### PR TITLE
 getting the readme back to business; added injectAllReactorProjects to the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk7
+  - openjdk6


### PR DESCRIPTION
Hi @ktoso,
I just tried to clean-up the readme a bit.
I rearranged a lot of things and therefore it seems to be a bit bigger PR.

I also readded the travis tests for java 6. I think as long as we support java we should include them....I'll create a ticket do drop this.