### PR TITLE
Fix for #191 slf4j simple-logger for logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <maven-plugin-api.version>3.1.1</maven-plugin-api.version>
 
     <jgit.version>3.7.0.201502260915-r</jgit.version>
+    <slf4j.version>1.7.12</slf4j.version>
     <junit.version>4.12</junit.version>
     <mockito.version>2.0.5-beta</mockito.version>
 
@@ -126,6 +127,18 @@
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
       <version>${jgit.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
 
     <!-- Test stuff -->

--- a/src/main/java/pl/project13/maven/git/log/MavenLoggerBridge.java
+++ b/src/main/java/pl/project13/maven/git/log/MavenLoggerBridge.java
@@ -15,19 +15,37 @@
  * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 package pl.project13.maven.git.log;
 
+import java.util.Properties;
+
 import com.google.common.base.Joiner;
+
 import org.apache.maven.plugin.logging.Log;
+import org.slf4j.Logger;
+import org.slf4j.impl.SimpleLogger;
+import org.slf4j.impl.SimpleLoggerFactory;
 
 public class MavenLoggerBridge implements LoggerBridge {
 
-  private final Log logger;
+  private Logger logger;
   private boolean verbose;
 
-  public MavenLoggerBridge(Log logger, boolean verbose) {
-    this.logger = logger;
+  public MavenLoggerBridge(Log log, boolean verbose) {
+    setSimpleLoggerPorperties();
+    this.logger = new SimpleLoggerFactory().getLogger(getClass().getName());
     this.verbose = verbose;
+  }
+
+  private void setSimpleLoggerPorperties() {
+    Properties sysProperties = System.getProperties();
+    if(!sysProperties.containsKey(SimpleLogger.SHOW_THREAD_NAME_KEY)){
+      System.setProperty(SimpleLogger.SHOW_THREAD_NAME_KEY, String.valueOf(false));
+    }
+    if(!sysProperties.containsKey(SimpleLogger.LEVEL_IN_BRACKETS_KEY)){
+      System.setProperty(SimpleLogger.LEVEL_IN_BRACKETS_KEY, String.valueOf(true));
+    }
   }
 
   @Override
@@ -43,7 +61,7 @@ public class MavenLoggerBridge implements LoggerBridge {
       logger.error(Joiner.on(" ").useForNull("null").join(parts));
     }
   }
-  
+
   @Override
   public void debug(Object... parts) {
     if (verbose) {
@@ -54,6 +72,10 @@ public class MavenLoggerBridge implements LoggerBridge {
   @Override
   public void setVerbose(boolean verbose) {
     this.verbose = verbose;
+  }
+
+  protected void setLogger(Logger logger){
+    this.logger = logger;
   }
 
 }

--- a/src/test/java/pl/project13/maven/git/log/MavenLoggerBridgeTest.java
+++ b/src/test/java/pl/project13/maven/git/log/MavenLoggerBridgeTest.java
@@ -1,16 +1,15 @@
 package pl.project13.maven.git.log;
 
-import org.apache.maven.plugin.logging.Log;
 import org.junit.Test;
+import org.slf4j.Logger;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+
 public class MavenLoggerBridgeTest {
-
-  Log logger = mock(Log.class);
-
-  MavenLoggerBridge bridge = new MavenLoggerBridge(logger, true);
+  Logger logger = mock(Logger.class);
+  MavenLoggerBridge bridge = new MavenLoggerBridge(null, true);
 
   @Test
   public void shouldNotFailWhenMessageContainsPercentSigns() throws Exception {
@@ -21,6 +20,7 @@ public class MavenLoggerBridgeTest {
     String expectedExplicit = "the output was: [ 100% coverage!!! ]";
 
     // when
+    bridge.setLogger(logger);
     bridge.log(start, content, end);
 
     // then


### PR DESCRIPTION
I'm just created the PR. 
Its way too late to actually pull this right in the repo...:-)

I also override some simple-logger's default properties to look like the normal maven log outpout. However those can still be overriden by setting -Dorg.slf4j.simpleLogger.showThreadName=true.


Link to issue: https://github.com/ktoso/maven-git-commit-id-plugin/issues/191