### PR TITLE
#54: Reveal describe details (tag name, number of commits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,11 +306,14 @@ git.commit.user.email=${git.commit.user.email}
 git.commit.message.full=${git.commit.message.full}
 git.commit.message.short=${git.commit.message.short}
 git.commit.time=${git.commit.time}
+git.closest.tag.name=${git.closest.tag.name}
+git.closest.tag.commit.count=${git.closest.tag.commit.count}
 
 git.build.user.name=${git.build.user.name}
 git.build.user.email=${git.build.user.email}
 git.build.time=${git.build.time}
 git.build.host=${git.build.host}
+git.build.version=${git.build.version}
 ```
 
 The `git` prefix may be configured in the plugin declaration above.
@@ -341,11 +344,14 @@ Start out with with adding the above steps to your project, next paste this **gi
         <property name="commitMessageFull" value="${git.commit.message.full}"/>
         <property name="commitMessageShort" value="${git.commit.message.short}"/>
         <property name="commitTime" value="${git.commit.time}"/>
+        <property name="closestTagName" value="${git.closest.tag.name}"/>
+        <property name="closestTagCommitCount" value="${git.closest.tag.commit.count}"/>
 
         <property name="buildUserName" value="${git.build.user.name}"/>
         <property name="buildUserEmail" value="${git.build.user.email}"/>
         <property name="buildTime" value="${git.build.time}"/>
         <property name="buildHost" value="${git.build.host}"/>
+        <porperty name="buildVersion" value="${git.build.version}"/>
     </bean>
 </beans>
 ```
@@ -378,12 +384,15 @@ public class GitRepositoryState {
   String commitMessageFull;       // =${git.commit.message.full}
   String commitMessageShort;      // =${git.commit.message.short}
   String commitTime;              // =${git.commit.time}
+  String closestTagName;          // =${git.closest.tag.name}
+  String closestTagCommitCount;   // =${git.closest.tag.commit.count}
 
   String buildUserName;           // =${git.build.user.name}
   String buildUserEmail;          // =${git.build.user.email}
   String buildTime;               // =${git.build.time}
   String buildHost;               // =${git.build.host}
-  
+  String buildVersion             // =${git.build.version}
+
   public GitRepositoryState() {
   }
   /* Generate setters and getters here */
@@ -438,11 +447,14 @@ In the end *this is what this service would return*:
                                 + added license etc",
          "commitMessageShort" : "releasing my fun plugin :-)",
          "commitTime" : "06.01.1970 @ 16:16:26 CET",
+         "closestTagName" : "v2.1.0",
+         "closestTagCommitCount" : "2",
          
          "buildUserName" : "Konrad Malawski",
          "buildUserEmail" : "konrad.malawski@java.pl",
          "buildTime" : "06.01.1970 @ 16:17:53 CET",
-         "buildHost" : "github.com"
+         "buildHost" : "github.com",
+         "buildVersion" : "v2.1.0-SNAPSHOT"
      }
 ```
 
@@ -503,11 +515,14 @@ public GitRepositoryState(Properties properties)
   this.commitMessageFull = properties.get("git.commit.message.full").toString();
   this.commitMessageShort = properties.get("git.commit.message.short").toString();
   this.commitTime = properties.get("git.commit.time").toString();
+  this.closestTagName = properties.get("git.closest.tag.name").toString();
+  this.closestTagCommitCount = properties.get("git.closest.tag.commit.count").toString();
 
   this.buildUserName = properties.get("git.build.user.name").toString();
   this.buildUserEmail = properties.get("git.build.user.email").toString();
   this.buildTime = properties.get("git.build.time").toString();
   this.buildHost = properties.get("git.build.host").toString();
+  this.buildVersion = properties.get("git.build.version").toString();
 }
 ```
 

--- a/src/main/java/pl/project13/jgit/DescribeCommand.java
+++ b/src/main/java/pl/project13/jgit/DescribeCommand.java
@@ -18,23 +18,17 @@
 package pl.project13.jgit;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.GitCommand;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
-import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.revwalk.RevTag;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -47,12 +41,9 @@ import pl.project13.maven.git.util.Pair;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.regex.Pattern;
 
 /**
  * Implements git's <pre>describe</pre> command.
- *
- * @author Konrad Malawski
  */
 public class DescribeCommand extends GitCommand<DescribeResult> {
 

--- a/src/main/java/pl/project13/jgit/DescribeCommand.java
+++ b/src/main/java/pl/project13/jgit/DescribeCommand.java
@@ -48,6 +48,7 @@ import java.util.*;
 public class DescribeCommand extends GitCommand<DescribeResult> {
 
   private LoggerBridge loggerBridge;
+  private JGitCommon jGitCommon;
 
 //  TODO not yet implemented options:
 //  private boolean containsFlag = false;
@@ -119,6 +120,12 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
   @NotNull
   public DescribeCommand withLoggerBridge(LoggerBridge bridge) {
     this.loggerBridge = bridge;
+    return this;
+  }
+
+  @NotNull
+  public DescribeCommand withJGitCommon(JGitCommon jGitCommon) {
+    this.jGitCommon = jGitCommon;
     return this;
   }
 
@@ -293,7 +300,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
     }
 
     // get commits, up until the nearest tag
-    List<RevCommit> commits = new JGitCommon().findCommitsUntilSomeTag(repo, headCommit, tagObjectIdToName);
+    List<RevCommit> commits = jGitCommon.findCommitsUntilSomeTag(repo, headCommit, tagObjectIdToName);
 
     // if there is no tags or any tag is not on that branch then return generic describe
     if (foundZeroTags(tagObjectIdToName) || commits.isEmpty()) {
@@ -303,7 +310,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
 
     // check how far away from a tag we are
 
-    int distance = new JGitCommon().distanceBetween(repo, headCommit, commits.get(0));
+    int distance = jGitCommon.distanceBetween(repo, headCommit, commits.get(0));
     String tagName = tagObjectIdToName.get(commits.get(0)).iterator().next();
     Pair<Integer, String> howFarFromWhichTag = Pair.of(distance, tagName);
 
@@ -387,8 +394,8 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
   // git commit id -> its tag (or tags)
   private Map<ObjectId, List<String>> findTagObjectIds(@NotNull Repository repo, boolean tagsFlag) {
 	  String matchPattern = createMatchPattern();
-	  Map<ObjectId, List<DatedRevTag>> commitIdsToTags = new JGitCommon().getCommitIdsToTags(loggerBridge, repo, tagsFlag, matchPattern);
-      Map<ObjectId, List<String>> commitIdsToTagNames = new JGitCommon().transformRevTagsMapToDateSortedTagNames(commitIdsToTags);
+	  Map<ObjectId, List<DatedRevTag>> commitIdsToTags = jGitCommon.getCommitIdsToTags(loggerBridge, repo, tagsFlag, matchPattern);
+      Map<ObjectId, List<String>> commitIdsToTagNames = jGitCommon.transformRevTagsMapToDateSortedTagNames(commitIdsToTags);
       log("Created map: [",commitIdsToTagNames,"] ");
 
       return commitIdsToTagNames;

--- a/src/main/java/pl/project13/jgit/DescribeCommand.java
+++ b/src/main/java/pl/project13/jgit/DescribeCommand.java
@@ -476,7 +476,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
     }
   }
 
-  private static void seeAllParents(@NotNull RevWalk revWalk, RevCommit child, @NotNull Set<ObjectId> seen) throws IOException {
+  private void seeAllParents(@NotNull RevWalk revWalk, RevCommit child, @NotNull Set<ObjectId> seen) throws IOException {
     Queue<RevCommit> q = newLinkedList();
     q.add(child);
 

--- a/src/main/java/pl/project13/jgit/DescribeCommand.java
+++ b/src/main/java/pl/project13/jgit/DescribeCommand.java
@@ -23,6 +23,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.GitCommand;
 import org.eclipse.jgit.api.Status;
@@ -37,6 +38,7 @@ import org.eclipse.jgit.revwalk.RevTag;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import pl.project13.jgit.dummy.DatedRevTag;
 import pl.project13.maven.git.GitDescribeConfig;
 import pl.project13.maven.git.log.LoggerBridge;
@@ -494,108 +496,12 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
 
   // git commit id -> its tag (or tags)
   private Map<ObjectId, List<String>> findTagObjectIds(@NotNull Repository repo, boolean tagsFlag) {
-    Map<ObjectId, List<DatedRevTag>> commitIdsToTags = newHashMap();
-
-    RevWalk walk = new RevWalk(repo);
-    try {
-      walk.markStart(walk.parseCommit(repo.resolve("HEAD")));
-
-      List<Ref> tagRefs = Git.wrap(repo).tagList().call();
-      String matchPattern = createMatchPattern();
-      Pattern regex = Pattern.compile(matchPattern);
-      log("Tag refs [", tagRefs, "]");
-
-      for (Ref tagRef : tagRefs) {
-        walk.reset();
-        String name = tagRef.getName();
-        if (!regex.matcher(name).matches()) {
-          log("Skipping tagRef with name [", name, "] as it doesn't match [", matchPattern, "]");
-          continue;
-        }
-        ObjectId resolvedCommitId = repo.resolve(name);
-
-        // todo that's a bit of a hack...
-        try {
-          final RevTag revTag = walk.parseTag(resolvedCommitId);
-          ObjectId taggedCommitId = revTag.getObject().getId();
-          log("Resolved tag [",revTag.getTagName(),"] [",revTag.getTaggerIdent(),"], points at [",taggedCommitId,"] ");
-
-          // sometimes a tag, may point to another tag, so we need to unpack it
-          while (isTagId(taggedCommitId)) {
-            taggedCommitId = walk.parseTag(taggedCommitId).getObject().getId();
-          }
-
-          if (commitIdsToTags.containsKey(taggedCommitId)) {
-            commitIdsToTags.get(taggedCommitId).add(new DatedRevTag(revTag));
-          } else {
-            commitIdsToTags.put(taggedCommitId, newArrayList(new DatedRevTag(revTag)));
-          }
-
-        } catch (IncorrectObjectTypeException ex) {
-          // it's an lightweight tag! (yeah, really)
-          if (tagsFlag) {
-            // --tags means "include lightweight tags"
-            log("Including lightweight tag [", name, "]");
-
-            DatedRevTag datedRevTag = new DatedRevTag(resolvedCommitId, name);
-
-            if (commitIdsToTags.containsKey(resolvedCommitId)) {
-              commitIdsToTags.get(resolvedCommitId).add(datedRevTag);
-            } else {
-              commitIdsToTags.put(resolvedCommitId, newArrayList(datedRevTag));
-            }
-          }
-        } catch (Exception ignored) {
-          error("Failed while parsing [",tagRef,"] -- ", Throwables.getStackTraceAsString(ignored));
-        }
-      }
-
-      for (Map.Entry<ObjectId, List<DatedRevTag>> entry : commitIdsToTags.entrySet()) {
-        log("key [",entry.getKey(),"], tags => [",entry.getValue(),"] ");
-      }
-
-      Map<ObjectId, List<String>> commitIdsToTagNames = transformRevTagsMapToDateSortedTagNames(commitIdsToTags);
-
+	  String matchPattern = createMatchPattern();
+	  Map<ObjectId, List<DatedRevTag>> commitIdsToTags = new JGitCommon().getCommitIdsToTags(loggerBridge, repo, tagsFlag, matchPattern);
+      Map<ObjectId, List<String>> commitIdsToTagNames = new JGitCommon().transformRevTagsMapToDateSortedTagNames(commitIdsToTags);
       log("Created map: [",commitIdsToTagNames,"] ");
 
       return commitIdsToTagNames;
-    } catch (Exception e) {
-      log("Unable to locate tags\n[",Throwables.getStackTraceAsString(e),"]");
-    } finally {
-      walk.release();
-    }
-
-    return Collections.emptyMap();
-  }
-
-  /** Checks if the given object id resolved to a tag object */
-  private boolean isTagId(ObjectId objectId) {
-    return objectId.toString().startsWith("tag ");
-  }
-
-  private HashMap<ObjectId, List<String>> transformRevTagsMapToDateSortedTagNames(Map<ObjectId, List<DatedRevTag>> commitIdsToTags) {
-    HashMap<ObjectId, List<String>> commitIdsToTagNames = newHashMap();
-    for (Map.Entry<ObjectId, List<DatedRevTag>> objectIdListEntry : commitIdsToTags.entrySet()) {
-      List<DatedRevTag> tags = objectIdListEntry.getValue();
-
-      List<DatedRevTag> newTags = newArrayList(tags);
-      Collections.sort(newTags, new Comparator<DatedRevTag>() {
-        @Override
-        public int compare(DatedRevTag revTag, DatedRevTag revTag2) {
-          return revTag2.date.compareTo(revTag.date);
-        }
-      });
-
-      List<String> tagNames = Lists.transform(newTags, new Function<DatedRevTag, String>() {
-        @Override
-        public String apply(DatedRevTag input) {
-          return trimFullTagName(input.tagName);
-        }
-      });
-
-      commitIdsToTagNames.put(objectIdListEntry.getKey(), tagNames);
-    }
-    return commitIdsToTagNames;
   }
 
   private String createMatchPattern() {
@@ -608,11 +514,6 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
     buf.append(matchOption.get().replace("*", "\\E.*\\Q").replace("?", "\\E.\\Q"));
     buf.append("\\E$");
     return buf.toString();
-  }
-
-  @VisibleForTesting
-  static String trimFullTagName(@NotNull String tagName) {
-    return tagName.replaceFirst("refs/tags/", "");
   }
 
   private void log(Object... parts) {

--- a/src/main/java/pl/project13/jgit/DescribeCommand.java
+++ b/src/main/java/pl/project13/jgit/DescribeCommand.java
@@ -105,6 +105,7 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
     super(repo);
     initDefaultLoggerBridge(verbose);
     setVerbose(verbose);
+    this.jGitCommon = new JGitCommon();
   }
 
   private void initDefaultLoggerBridge(boolean verbose) {
@@ -120,12 +121,6 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
   @NotNull
   public DescribeCommand withLoggerBridge(LoggerBridge bridge) {
     this.loggerBridge = bridge;
-    return this;
-  }
-
-  @NotNull
-  public DescribeCommand withJGitCommon(JGitCommon jGitCommon) {
-    this.jGitCommon = jGitCommon;
     return this;
   }
 

--- a/src/main/java/pl/project13/jgit/DescribeCommand.java
+++ b/src/main/java/pl/project13/jgit/DescribeCommand.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/pl/project13/jgit/DescribeResult.java
+++ b/src/main/java/pl/project13/jgit/DescribeResult.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/pl/project13/jgit/JGitCommon.java
+++ b/src/main/java/pl/project13/jgit/JGitCommon.java
@@ -59,10 +59,6 @@ import static com.google.common.collect.Lists.newLinkedList;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 
-
-/**
- * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
- */
 public class JGitCommon {
   public Collection<String> getTags(Repository repo, final ObjectId headId) throws GitAPIException{
     RevWalk walk = null;

--- a/src/main/java/pl/project13/jgit/JGitCommon.java
+++ b/src/main/java/pl/project13/jgit/JGitCommon.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.project13.jgit;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevWalk;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+
+/**
+ * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
+ */
+public class JGitCommon {
+  public Collection<String> getTags(Repository repo, final ObjectId headId) throws GitAPIException{
+    RevWalk walk = null;
+    try {
+      Git git = Git.wrap(repo);
+      walk = new RevWalk(repo);
+      List<Ref> tagRefs = git.tagList().call();
+
+      final RevWalk finalWalk = walk;
+      Collection<Ref> tagsForHeadCommit = Collections2.filter(tagRefs, new Predicate<Ref>() {
+        @Override public boolean apply(Ref tagRef) {
+        boolean lightweightTag = tagRef.getObjectId().equals(headId);
+
+          try {
+            // TODO make this configurable (most users shouldn't really care too much what kind of tag it is though)
+            return lightweightTag || finalWalk.parseTag(tagRef.getObjectId()).getObject().getId().equals(headId); // or normal tag
+          } catch (IOException e) {
+            return false;
+          }
+        }
+      });
+
+      Collection<String> tags = Collections2.transform(tagsForHeadCommit, new Function<Ref, String>() {
+        @Override public String apply(Ref input) {
+          return input.getName().replaceAll("refs/tags/", "");
+        }
+      });
+
+      return tags;
+    } catch (GitAPIException e) {
+      throw e;
+    } finally {
+      if (walk != null) {
+        walk.dispose();
+      }
+    }
+  }
+
+}

--- a/src/main/java/pl/project13/jgit/JGitCommon.java
+++ b/src/main/java/pl/project13/jgit/JGitCommon.java
@@ -17,20 +17,37 @@
 
 package pl.project13.jgit;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
+
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevTag;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.jetbrains.annotations.NotNull;
 
+import pl.project13.jgit.dummy.DatedRevTag;
+import pl.project13.maven.git.log.LoggerBridge;
+
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
 
 /**
  * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
@@ -71,6 +88,109 @@ public class JGitCommon {
         walk.dispose();
       }
     }
+  }
+  
+  protected Map<ObjectId, List<DatedRevTag>> getCommitIdsToTags(@NotNull LoggerBridge loggerBridge,@NotNull Repository repo, boolean tagsFlag, String matchPattern){
+    Map<ObjectId, List<DatedRevTag>> commitIdsToTags = newHashMap();
+
+    RevWalk walk = new RevWalk(repo);
+    try {
+      walk.markStart(walk.parseCommit(repo.resolve("HEAD")));
+
+      List<Ref> tagRefs = Git.wrap(repo).tagList().call();
+      Pattern regex = Pattern.compile(matchPattern);
+      loggerBridge.log("Tag refs [", tagRefs, "]");
+
+      for (Ref tagRef : tagRefs) {
+        walk.reset();
+        String name = tagRef.getName();
+        if (!regex.matcher(name).matches()) {
+          loggerBridge.log("Skipping tagRef with name [", name, "] as it doesn't match [", matchPattern, "]");
+          continue;
+        }
+        ObjectId resolvedCommitId = repo.resolve(name);
+
+        // TODO that's a bit of a hack...
+        try {
+          final RevTag revTag = walk.parseTag(resolvedCommitId);
+          ObjectId taggedCommitId = revTag.getObject().getId();
+          loggerBridge.log("Resolved tag [",revTag.getTagName(),"] [",revTag.getTaggerIdent(),"], points at [",taggedCommitId,"] ");
+
+          // sometimes a tag, may point to another tag, so we need to unpack it
+          while (isTagId(taggedCommitId)) {
+            taggedCommitId = walk.parseTag(taggedCommitId).getObject().getId();
+          }
+
+          if (commitIdsToTags.containsKey(taggedCommitId)) {
+            commitIdsToTags.get(taggedCommitId).add(new DatedRevTag(revTag));
+          } else {
+            commitIdsToTags.put(taggedCommitId, newArrayList(new DatedRevTag(revTag)));
+          }
+
+        } catch (IncorrectObjectTypeException ex) {
+          // it's an lightweight tag! (yeah, really)
+          if (tagsFlag) {
+            // --tags means "include lightweight tags"
+            loggerBridge.log("Including lightweight tag [", name, "]");
+
+            DatedRevTag datedRevTag = new DatedRevTag(resolvedCommitId, name);
+
+            if (commitIdsToTags.containsKey(resolvedCommitId)) {
+              commitIdsToTags.get(resolvedCommitId).add(datedRevTag);
+            } else {
+              commitIdsToTags.put(resolvedCommitId, newArrayList(datedRevTag));
+            }
+          }
+        } catch (Exception ignored) {
+          loggerBridge.error("Failed while parsing [",tagRef,"] -- ", Throwables.getStackTraceAsString(ignored));
+        }
+      }
+
+      for (Map.Entry<ObjectId, List<DatedRevTag>> entry : commitIdsToTags.entrySet()) {
+        loggerBridge.log("key [",entry.getKey(),"], tags => [",entry.getValue(),"] ");
+      }
+        return commitIdsToTags;
+    } catch (Exception e) {
+      loggerBridge.log("Unable to locate tags\n[",Throwables.getStackTraceAsString(e),"]");
+    } finally {
+      walk.release();
+    }
+    return Collections.emptyMap();
+  }
+
+  /** Checks if the given object id resolved to a tag object */
+  private boolean isTagId(ObjectId objectId) {
+    return objectId.toString().startsWith("tag ");
+  }
+
+  protected HashMap<ObjectId, List<String>> transformRevTagsMapToDateSortedTagNames(Map<ObjectId, List<DatedRevTag>> commitIdsToTags) {
+    HashMap<ObjectId, List<String>> commitIdsToTagNames = newHashMap();
+    for (Map.Entry<ObjectId, List<DatedRevTag>> objectIdListEntry : commitIdsToTags.entrySet()) {
+      List<DatedRevTag> tags = objectIdListEntry.getValue();
+
+      List<DatedRevTag> newTags = newArrayList(tags);
+      Collections.sort(newTags, new Comparator<DatedRevTag>() {
+        @Override
+        public int compare(DatedRevTag revTag, DatedRevTag revTag2) {
+          return revTag2.date.compareTo(revTag.date);
+        }
+      });
+
+      List<String> tagNames = Lists.transform(newTags, new Function<DatedRevTag, String>() {
+        @Override
+        public String apply(DatedRevTag input) {
+          return trimFullTagName(input.tagName);
+        }
+      });
+
+      commitIdsToTagNames.put(objectIdListEntry.getKey(), tagNames);
+    }
+    return commitIdsToTagNames;
+  }
+
+  @VisibleForTesting
+  protected String trimFullTagName(@NotNull String tagName) {
+    return tagName.replaceFirst("refs/tags/", "");
   }
 
 }

--- a/src/main/java/pl/project13/jgit/JGitCommon.java
+++ b/src/main/java/pl/project13/jgit/JGitCommon.java
@@ -25,8 +25,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.eclipse.jgit.api.Git;
@@ -35,6 +39,7 @@ import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTag;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.jetbrains.annotations.NotNull;
@@ -48,6 +53,12 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Lists.newLinkedList;
+import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Sets.newHashSet;
+
 
 /**
  * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
@@ -89,8 +100,65 @@ public class JGitCommon {
       }
     }
   }
-  
-  protected Map<ObjectId, List<DatedRevTag>> getCommitIdsToTags(@NotNull LoggerBridge loggerBridge,@NotNull Repository repo, boolean tagsFlag, String matchPattern){
+
+  public String getClosestTagName(@NotNull LoggerBridge loggerBridge,@NotNull Repository repo){
+    Map<ObjectId, List<DatedRevTag>> map = getClosestTagAsMap(loggerBridge,repo);
+    for(Map.Entry<ObjectId, List<DatedRevTag>> entry : map.entrySet()){
+      return trimFullTagName(entry.getValue().get(0).tagName);
+    }
+    return "";
+  }
+
+  public String getClosestTagCommitCount(@NotNull LoggerBridge loggerBridge,@NotNull Repository repo, RevCommit headCommit){    
+    HashMap<ObjectId, List<String>> map = transformRevTagsMapToDateSortedTagNames(getClosestTagAsMap(loggerBridge,repo));
+    ObjectId obj = (ObjectId) map.keySet().toArray()[0];
+    
+    RevWalk walk = new RevWalk(repo);
+    RevCommit commit = walk.lookupCommit(obj);
+    walk.dispose();
+    
+    int distance = distanceBetween(repo, headCommit, commit);
+    return String.valueOf(distance);
+  }
+
+  private Map<ObjectId, List<DatedRevTag>> getClosestTagAsMap(@NotNull LoggerBridge loggerBridge,@NotNull Repository repo){
+    Map<ObjectId, List<DatedRevTag>> mapWithClosestTagOnly = newHashMap();
+    boolean includeLightweightTags = true;
+    String matchPattern = ".*";
+    Map<ObjectId, List<DatedRevTag>> commitIdsToTags = getCommitIdsToTags(loggerBridge,repo,includeLightweightTags,matchPattern);
+    LinkedHashMap<ObjectId, List<DatedRevTag>> sortedCommitIdsToTags = sortByDatedRevTag(commitIdsToTags);
+
+    for(Map.Entry<ObjectId, List<DatedRevTag>> entry: sortedCommitIdsToTags.entrySet()){
+      mapWithClosestTagOnly.put(entry.getKey(), entry.getValue());
+      break;
+    }
+
+    return mapWithClosestTagOnly;
+  }
+
+  private LinkedHashMap<ObjectId, List<DatedRevTag>> sortByDatedRevTag(Map<ObjectId, List<DatedRevTag>> map) {
+    List<Map.Entry<ObjectId, List<DatedRevTag>>> list = new LinkedList<Map.Entry<ObjectId, List<DatedRevTag>>>(map.entrySet());
+
+    Collections.sort(list, new Comparator<Map.Entry<ObjectId, List<DatedRevTag>>>() {
+      public int compare(Map.Entry<ObjectId, List<DatedRevTag>> m1, Map.Entry<ObjectId, List<DatedRevTag>> m2) {
+        // we need to sort the DatedRevTags to a commit first, otherwise we may get problems when we have two tags for the same commit
+        Collections.sort(m1.getValue(), datedRevTagComparator());
+        Collections.sort(m2.getValue(), datedRevTagComparator());
+
+        DatedRevTag datedRevTag1 = m1.getValue().get(0);
+        DatedRevTag datedRevTag2 = m2.getValue().get(0);
+        return datedRevTagComparator().compare(datedRevTag1,datedRevTag2);
+      }
+    });
+
+    LinkedHashMap<ObjectId, List<DatedRevTag>> result = new LinkedHashMap<ObjectId, List<DatedRevTag>>();
+    for (Map.Entry<ObjectId, List<DatedRevTag>> entry : list) {
+      result.put(entry.getKey(), entry.getValue());
+    }
+    return result;
+  }
+
+  protected Map<ObjectId, List<DatedRevTag>> getCommitIdsToTags(@NotNull LoggerBridge loggerBridge,@NotNull Repository repo, boolean includeLightweightTags, String matchPattern){
     Map<ObjectId, List<DatedRevTag>> commitIdsToTags = newHashMap();
 
     RevWalk walk = new RevWalk(repo);
@@ -129,7 +197,7 @@ public class JGitCommon {
 
         } catch (IncorrectObjectTypeException ex) {
           // it's an lightweight tag! (yeah, really)
-          if (tagsFlag) {
+          if (includeLightweightTags) {
             // --tags means "include lightweight tags"
             loggerBridge.log("Including lightweight tag [", name, "]");
 
@@ -166,31 +234,134 @@ public class JGitCommon {
   protected HashMap<ObjectId, List<String>> transformRevTagsMapToDateSortedTagNames(Map<ObjectId, List<DatedRevTag>> commitIdsToTags) {
     HashMap<ObjectId, List<String>> commitIdsToTagNames = newHashMap();
     for (Map.Entry<ObjectId, List<DatedRevTag>> objectIdListEntry : commitIdsToTags.entrySet()) {
-      List<DatedRevTag> tags = objectIdListEntry.getValue();
-
-      List<DatedRevTag> newTags = newArrayList(tags);
-      Collections.sort(newTags, new Comparator<DatedRevTag>() {
-        @Override
-        public int compare(DatedRevTag revTag, DatedRevTag revTag2) {
-          return revTag2.date.compareTo(revTag.date);
-        }
-      });
-
-      List<String> tagNames = Lists.transform(newTags, new Function<DatedRevTag, String>() {
-        @Override
-        public String apply(DatedRevTag input) {
-          return trimFullTagName(input.tagName);
-        }
-      });
+      List<String> tagNames = transformRevTagsMapEntryToDateSortedTagNames(objectIdListEntry);
 
       commitIdsToTagNames.put(objectIdListEntry.getKey(), tagNames);
     }
     return commitIdsToTagNames;
   }
 
+  private List<String> transformRevTagsMapEntryToDateSortedTagNames(Map.Entry<ObjectId, List<DatedRevTag>> objectIdListEntry) {
+    List<DatedRevTag> tags = objectIdListEntry.getValue();
+
+    List<DatedRevTag> newTags = newArrayList(tags);
+    Collections.sort(newTags, datedRevTagComparator());
+
+    List<String> tagNames = Lists.transform(newTags, new Function<DatedRevTag, String>() {
+      @Override
+      public String apply(DatedRevTag input) {
+        return trimFullTagName(input.tagName);
+      }
+    });
+    return tagNames;
+  }
+
+  private Comparator<DatedRevTag> datedRevTagComparator() {
+    return new Comparator<DatedRevTag>() {
+        @Override
+        public int compare(DatedRevTag revTag, DatedRevTag revTag2) {
+          return revTag2.date.compareTo(revTag.date);
+        }
+      };
+  }
+
   @VisibleForTesting
   protected String trimFullTagName(@NotNull String tagName) {
     return tagName.replaceFirst("refs/tags/", "");
+  }
+
+  public List<RevCommit> findCommitsUntilSomeTag(Repository repo, RevCommit head, @NotNull Map<ObjectId, List<String>> tagObjectIdToName) {
+    RevWalk revWalk = new RevWalk(repo);
+    try {
+      revWalk.markStart(head);
+
+      for (RevCommit commit : revWalk) {
+        ObjectId objId = commit.getId();
+        if (tagObjectIdToName.size() > 0) {
+          List<String> maybeList = tagObjectIdToName.get(objId);
+          if (maybeList != null && maybeList.get(0) != null) {
+            return Collections.singletonList(commit);
+          }
+        }
+      }
+
+      return Collections.emptyList();
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to find commits until some tag", e);
+    }
+  }
+
+   /**
+   * Calculates the distance (number of commits) between the given parent and child commits.
+   *
+   * @return distance (number of commits) between the given commits
+   * @see <a href="https://github.com/mdonoughe/jgit-describe/blob/master/src/org/mdonoughe/JGitDescribeTask.java">mdonoughe/jgit-describe/blob/master/src/org/mdonoughe/JGitDescribeTask.java</a>
+   */
+  protected int distanceBetween(@NotNull Repository repo, @NotNull RevCommit child, @NotNull RevCommit parent) {
+    RevWalk revWalk = new RevWalk(repo);
+
+    try {
+      revWalk.markStart(child);
+
+      Set<ObjectId> seena = newHashSet();
+      Set<ObjectId> seenb = newHashSet();
+      Queue<RevCommit> q = newLinkedList();
+
+      q.add(revWalk.parseCommit(child));
+      int distance = 0;
+      ObjectId parentId = parent.getId();
+
+      while (q.size() > 0) {
+        RevCommit commit = q.remove();
+        ObjectId commitId = commit.getId();
+
+        if (seena.contains(commitId)) {
+          continue;
+        }
+        seena.add(commitId);
+
+        if (parentId.equals(commitId)) {
+          // don't consider commits that are included in this commit
+          seeAllParents(revWalk, commit, seenb);
+          // remove things we shouldn't have included
+          for (ObjectId oid : seenb) {
+            if (seena.contains(oid)) {
+              distance--;
+            }
+          }
+          seena.addAll(seenb);
+          continue;
+        }
+
+        for (ObjectId oid : commit.getParents()) {
+          if (!seena.contains(oid)) {
+            q.add(revWalk.parseCommit(oid));
+          }
+        }
+        distance++;
+      }
+      return distance;
+    } catch (Exception e) {
+      throw new RuntimeException(String.format("Unable to calculate distance between [%s] and [%s]", child, parent), e);
+    } finally {
+      revWalk.dispose();
+    }
+  }
+
+  private void seeAllParents(@NotNull RevWalk revWalk, RevCommit child, @NotNull Set<ObjectId> seen) throws IOException {
+    Queue<RevCommit> q = newLinkedList();
+    q.add(child);
+
+    while (q.size() > 0) {
+      RevCommit commit = q.remove();
+      for (ObjectId oid : commit.getParents()) {
+        if (seen.contains(oid)) {
+          continue;
+        }
+        seen.add(oid);
+        q.add(revWalk.parseCommit(oid));
+      }
+    }
   }
 
 }

--- a/src/main/java/pl/project13/jgit/JGitCommon.java
+++ b/src/main/java/pl/project13/jgit/JGitCommon.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/pl/project13/jgit/dummy/DatedRevTag.java
+++ b/src/main/java/pl/project13/jgit/dummy/DatedRevTag.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package pl.project13.jgit.dummy;
 
 import org.eclipse.jgit.lib.AnyObjectId;

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -53,7 +53,6 @@ import java.util.Properties;
 /**
  * Goal which puts git build-time information into property files or maven's properties.
  *
- * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
  * @goal revision
  * @phase initialize
  * @requiresProject

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -82,6 +82,8 @@ public class GitCommitIdMojo extends AbstractMojo {
   public static final String COMMIT_TIME = "commit.time";
   public static final String REMOTE_ORIGIN_URL = "remote.origin.url";
   public static final String TAGS = "tags";
+  public static final String CLOSEST_TAG_NAME = "closest.tag.name";
+  public static final String CLOSEST_TAG_COMMIT_COUNT = "closest.tag.commit.count";
 
   /**
    * The maven project.

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -69,6 +69,8 @@ public abstract class GitDataProvider {
   protected abstract String getCommitTime();
   protected abstract String getRemoteOriginUrl() throws MojoExecutionException;
   protected abstract String getTags() throws MojoExecutionException;
+  protected abstract String getClosestTagName() throws MojoExecutionException;
+  protected abstract String getClosestTagCommitCount() throws MojoExecutionException;
   protected abstract void finalCleanUp();
 
   public void loadGitData(@NotNull Properties properties) throws IOException, MojoExecutionException{
@@ -107,6 +109,9 @@ public abstract class GitDataProvider {
 
       //
       put(properties, GitCommitIdMojo.TAGS, getTags());
+      
+      put(properties,GitCommitIdMojo.CLOSEST_TAG_NAME, getClosestTagName());
+      put(properties,GitCommitIdMojo.CLOSEST_TAG_COMMIT_COUNT, getClosestTagCommitCount());
     } finally {
       finalCleanUp();
     }

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package pl.project13.maven.git;
 
 import org.apache.maven.plugin.MojoExecutionException;

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -28,9 +28,6 @@ import java.util.Properties;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
-/**
- * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
- */
 public abstract class GitDataProvider {
 
   @NotNull

--- a/src/main/java/pl/project13/maven/git/GitDescribeConfig.java
+++ b/src/main/java/pl/project13/maven/git/GitDescribeConfig.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/pl/project13/maven/git/GitDirLocator.java
+++ b/src/main/java/pl/project13/maven/git/GitDirLocator.java
@@ -28,7 +28,6 @@ import java.util.List;
 /**
  * Encapsulates logic to locate a valid .git directory.
  *
- * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
  */
 public class GitDirLocator {
   final MavenProject mavenProject;

--- a/src/main/java/pl/project13/maven/git/GitDirLocator.java
+++ b/src/main/java/pl/project13/maven/git/GitDirLocator.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/pl/project13/maven/git/GitRepositoryState.java
+++ b/src/main/java/pl/project13/maven/git/GitRepositoryState.java
@@ -21,7 +21,6 @@ package pl.project13.maven.git;
 import com.google.common.base.Joiner;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -29,7 +28,6 @@ import java.util.Set;
  * with properties about the repository state at build time.
  * This information is supplied by my plugin - <b>pl.project13.maven.git-commit-id-plugin</b>
  *
- * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
  * @since 1.0
  */
 //@JsonWriteNullProperties(true)

--- a/src/main/java/pl/project13/maven/git/GitRepositoryState.java
+++ b/src/main/java/pl/project13/maven/git/GitRepositoryState.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package pl.project13.maven.git;
 
 //import org.codehaus.jackson.annotate.JsonWriteNullProperties;

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package pl.project13.maven.git;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -54,6 +54,7 @@ public class JGitProvider extends GitDataProvider {
   private ObjectReader objectReader;
   private RevWalk revWalk;
   private RevCommit headCommit;
+  private JGitCommon jGitCommon;
 
   @NotNull
   public static JGitProvider on(@NotNull File dotGitDirectory, @NotNull LoggerBridge loggerBridge) {
@@ -63,6 +64,7 @@ public class JGitProvider extends GitDataProvider {
   JGitProvider(@NotNull File dotGitDirectory, @NotNull LoggerBridge loggerBridge) {
     super(loggerBridge);
     this.dotGitDirectory = dotGitDirectory;
+    this.jGitCommon = new JGitCommon();
   }
 
   @NotNull
@@ -189,7 +191,7 @@ public class JGitProvider extends GitDataProvider {
     try {
       Repository repo = getGitRepository();
       ObjectId headId = headCommit.toObjectId();
-      Collection<String> tags = new JGitCommon().getTags(repo,headId);
+      Collection<String> tags = jGitCommon.getTags(repo,headId);
       return Joiner.on(",").join(tags);
     } catch (GitAPIException e) {
       loggerBridge.error("Unable to extract tags from commit: " + headCommit.getName() + " (" + e.getClass().getName() + ")");
@@ -201,7 +203,7 @@ public class JGitProvider extends GitDataProvider {
   protected String getClosestTagName() throws MojoExecutionException {
     Repository repo = getGitRepository();
     try {
-      return new JGitCommon().getClosestTagName(loggerBridge,repo);
+      return jGitCommon.getClosestTagName(loggerBridge,repo);
     } catch (Throwable t) {
       // could not find any tags to describe
     }
@@ -212,7 +214,7 @@ public class JGitProvider extends GitDataProvider {
   protected String getClosestTagCommitCount() throws MojoExecutionException {
     Repository repo = getGitRepository();
     try {
-      return new JGitCommon().getClosestTagCommitCount(loggerBridge,repo,headCommit);
+      return jGitCommon.getClosestTagCommitCount(loggerBridge,repo,headCommit);
     } catch (Throwable t) {
       // could not find any tags to describe
     }
@@ -232,6 +234,7 @@ public class JGitProvider extends GitDataProvider {
       DescribeResult describeResult = DescribeCommand
         .on(repository)
         .withLoggerBridge(super.loggerBridge)
+        .withJGitCommon(jGitCommon)
         .setVerbose(super.verbose)
         .apply(super.gitDescribe)
         .call();

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -234,7 +234,6 @@ public class JGitProvider extends GitDataProvider {
       DescribeResult describeResult = DescribeCommand
         .on(repository)
         .withLoggerBridge(super.loggerBridge)
-        .withJGitCommon(jGitCommon)
         .setVerbose(super.verbose)
         .apply(super.gitDescribe)
         .call();

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -18,12 +18,8 @@
 package pl.project13.maven.git;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.eclipse.jgit.api.Git;
@@ -51,9 +47,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-/**
- * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
- */
 public class JGitProvider extends GitDataProvider {
 
   private File dotGitDirectory;

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -188,6 +188,28 @@ public class JGitProvider extends GitDataProvider {
   }
 
   @Override
+  protected String getClosestTagName() throws MojoExecutionException {
+    Repository repo = getGitRepository();
+    try {
+      return new JGitCommon().getClosestTagName(loggerBridge,repo);
+    } catch (Throwable t) {
+      // could not find any tags to describe
+    }
+    return "";
+  }
+
+  @Override
+  protected String getClosestTagCommitCount() throws MojoExecutionException {
+    Repository repo = getGitRepository();
+    try {
+      return new JGitCommon().getClosestTagCommitCount(loggerBridge,repo,headCommit);
+    } catch (Throwable t) {
+      // could not find any tags to describe
+    }
+    return "";
+  }
+
+  @Override
   protected void finalCleanUp() {
     if (revWalk != null) {
       revWalk.dispose();

--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -1,3 +1,19 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package pl.project13.maven.git;
 
 import static java.lang.String.format;

--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -204,6 +204,25 @@ public class NativeGitProvider extends GitDataProvider {
   protected String getRemoteOriginUrl() throws MojoExecutionException {
     return getOriginRemote(canonical);
   }
+  
+  @Override
+  protected String getClosestTagName(){
+    try {
+      return runGitCommand(canonical, "describe --abbrev=0 --tags");
+    } catch (NativeCommandException ignore) {
+      // could not find any tags to describe
+    }
+    return "";
+  }
+
+  @Override
+  protected String getClosestTagCommitCount(){
+    String closestTagName = getClosestTagName();
+    if(closestTagName != null && !closestTagName.trim().isEmpty()){
+      return runQuietGitCommand(canonical, "rev-list "+closestTagName+"..HEAD --count");
+    }
+    return "";
+  }
 
   @Override
   protected void finalCleanUp() {

--- a/src/main/java/pl/project13/maven/git/log/LoggerBridge.java
+++ b/src/main/java/pl/project13/maven/git/log/LoggerBridge.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/pl/project13/maven/git/log/MavenLoggerBridge.java
+++ b/src/main/java/pl/project13/maven/git/log/MavenLoggerBridge.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 
 package pl.project13.maven.git.log;
 

--- a/src/main/java/pl/project13/maven/git/log/StdOutLoggerBridge.java
+++ b/src/main/java/pl/project13/maven/git/log/StdOutLoggerBridge.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/pl/project13/maven/git/util/Pair.java
+++ b/src/main/java/pl/project13/maven/git/util/Pair.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/pl/project13/maven/git/util/PropertyManager.java
+++ b/src/main/java/pl/project13/maven/git/util/PropertyManager.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package pl.project13.maven.git.util;
 
 import java.util.Properties;

--- a/src/test/java/pl/project13/jgit/DescribeCommandAbbrevIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandAbbrevIntegrationTest.java
@@ -1,22 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
- *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-/*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/jgit/DescribeCommandIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandIntegrationTest.java
@@ -432,18 +432,6 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
     assertThat(objectId.getName()).isNotEmpty();
   }
 
-  @Test
-  public void trimFullTagName_shouldTrimFullTagNamePrefix() throws Exception {
-    // given
-    String fullName = "refs/tags/v1.0.0";
-
-    // when
-    String simpleName = DescribeCommand.trimFullTagName(fullName);
-
-    // then
-    assertThat(simpleName).isEqualTo("v1.0.0");
-  }
-
   String abbrev(@NotNull String id) {
     return abbrev(id, DEFAULT_ABBREV_LEN);
   }

--- a/src/test/java/pl/project13/jgit/DescribeCommandIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/jgit/DescribeCommandOptionsTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandOptionsTest.java
@@ -1,22 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
- *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-/*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/jgit/DescribeCommandTagsIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandTagsIntegrationTest.java
@@ -1,22 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
- *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-/*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/jgit/DescribeResultTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeResultTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/jgit/JGitCommonIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/JGitCommonIntegrationTest.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pl.project13.jgit;
+
+import org.junit.Test;
+import pl.project13.maven.git.GitIntegrationTest;
+import static org.fest.assertions.Assertions.assertThat;
+
+public class JGitCommonIntegrationTest extends GitIntegrationTest {
+
+  @Test
+  public void trimFullTagName_shouldTrimFullTagNamePrefix() throws Exception {
+    // given
+    String fullName = "refs/tags/v1.0.0";
+
+    // when
+    String simpleName = new JGitCommon().trimFullTagName(fullName);
+
+    // then
+    assertThat(simpleName).isEqualTo("v1.0.0");
+  }
+}

--- a/src/test/java/pl/project13/jgit/JGitCommonIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/JGitCommonIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/AvailableGitTestRepo.java
+++ b/src/test/java/pl/project13/maven/git/AvailableGitTestRepo.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/ContainsKeyCondition.java
+++ b/src/test/java/pl/project13/maven/git/ContainsKeyCondition.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/DoesNotContainKeyCondition.java
+++ b/src/test/java/pl/project13/maven/git/DoesNotContainKeyCondition.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
+++ b/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
@@ -33,7 +33,6 @@ import com.google.common.io.Files;
  * Copies sample git repository from prototype location to newly created project
  * Has ability to set target project for storing git repository
  *
- * @author mostr
  */
 public class FileSystemMavenSandbox {
 

--- a/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
+++ b/src/test/java/pl/project13/maven/git/FileSystemMavenSandbox.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoDirtyFilesTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoDirtyFilesTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoDirtyFilesTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoDirtyFilesTest.java
@@ -17,24 +17,16 @@
 
 package pl.project13.maven.git;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
+
 import org.apache.maven.project.MavenProject;
-import org.eclipse.jgit.lib.Repository;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.Map;
 import java.util.Properties;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-/**
- * @author Adam Batkin
- */
 public class GitCommitIdMojoDirtyFilesTest {
 
   @Test

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -657,6 +657,95 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     }
   }
 
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldGenerateClosestTagInformationWhenOnATag(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-pom-project", "pom")
+                .withChildProject("my-jar-module", "jar")
+                .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG)
+                .create(CleanUp.CLEANUP_FIRST);
+
+    MavenProject targetProject = mavenSandbox.getChildProject();
+
+    setProjectToExecuteMojoIn(targetProject);
+    GitDescribeConfig gitDescribeConfig = createGitDescribeConfig(false, 7);
+    gitDescribeConfig.setDirty("-dirty"); // checking if dirty works as expected
+
+    alterMojoSettings("gitDescribe", gitDescribeConfig);
+    alterMojoSettings("useNativeGit", useNativeGit);
+
+    // when
+    mojo.execute();
+
+    // then
+    assertThat(targetProject.getProperties().stringPropertyNames()).contains("git.closest.tag.name");
+    assertThat(targetProject.getProperties().getProperty("git.closest.tag.name")).isEqualTo("v1.0.0");
+
+    assertThat(targetProject.getProperties().stringPropertyNames()).contains("git.closest.tag.commit.count");
+    assertThat(targetProject.getProperties().getProperty("git.closest.tag.commit.count")).isEqualTo("0");
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldGenerateClosestTagInformationWhenOnATagAndDirty(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-pom-project", "pom")
+                .withChildProject("my-jar-module", "jar")
+                .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG_DIRTY)
+                .create(CleanUp.CLEANUP_FIRST);
+    MavenProject targetProject = mavenSandbox.getChildProject();
+
+    setProjectToExecuteMojoIn(targetProject);
+
+    GitDescribeConfig gitDescribeConfig = createGitDescribeConfig(true, 7);
+    String dirtySuffix = "-dirtyTest";
+    gitDescribeConfig.setDirty(dirtySuffix);
+    alterMojoSettings("gitDescribe", gitDescribeConfig);
+    alterMojoSettings("useNativeGit", useNativeGit);
+
+    // when
+    mojo.execute();
+
+    // then
+    assertThat(targetProject.getProperties().stringPropertyNames()).contains("git.closest.tag.name");
+    assertThat(targetProject.getProperties().getProperty("git.closest.tag.name")).isEqualTo("v1.0.0");
+
+    assertThat(targetProject.getProperties().stringPropertyNames()).contains("git.closest.tag.commit.count");
+    assertThat(targetProject.getProperties().getProperty("git.closest.tag.commit.count")).isEqualTo("0");
+  }  
+
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldGenerateClosestTagInformationWhenCommitHasTwoTags(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox
+      .withParentProject("my-jar-project", "jar")
+      .withNoChildProject()
+      .withGitRepoInParent(AvailableGitTestRepo.WITH_COMMIT_THAT_HAS_TWO_TAGS)
+      .create(CleanUp.CLEANUP_FIRST);
+
+    git("my-jar-project").reset().setMode(ResetCommand.ResetType.HARD).setRef("d37a598").call();
+
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+
+    alterMojoSettings("gitDescribe", null);
+    alterMojoSettings("useNativeGit", useNativeGit);
+
+    // when
+    mojo.execute();
+
+    // then
+    // AvailableGitTestRepo.WITH_COMMIT_THAT_HAS_TWO_TAGS ==> Where the newest-tag was created latest
+    assertThat(targetProject.getProperties().stringPropertyNames()).contains("git.closest.tag.name");
+    assertThat(targetProject.getProperties().getProperty("git.closest.tag.name")).isEqualTo("newest-tag");
+
+    assertThat(targetProject.getProperties().stringPropertyNames()).contains("git.closest.tag.commit.count");
+    assertThat(targetProject.getProperties().getProperty("git.closest.tag.commit.count")).isEqualTo("0");
+  }
+
   private GitDescribeConfig createGitDescribeConfig(boolean forceLongFormat, int abbrev) {
     GitDescribeConfig gitDescribeConfig = new GitDescribeConfig();
     gitDescribeConfig.setTags(true);
@@ -685,5 +774,8 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.short"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.time"));
     assertThat(properties).satisfies(new ContainsKeyCondition("git.remote.origin.url"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.closest.tag.name"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.closest.tag.commit.count"));
+
   }
 }

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.*;
 /**
  * I'm not a big fan of this test - let's move to integration test from now on.
  *
- * @author <a href="mailto:konrad.malawski@java.pl">Konrad 'ktoso' Malawski</a>
  */
 // todo remove this test in favor of complete intgration tests
 public class GitCommitIdMojoTest {

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
+++ b/src/test/java/pl/project13/maven/git/GitDirLocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/GitSubmodulesTest.java
+++ b/src/test/java/pl/project13/maven/git/GitSubmodulesTest.java
@@ -1,22 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
- *
- * git-commit-id-plugin is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * git-commit-id-plugin is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-/*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/NaivePerformanceTest.java
+++ b/src/test/java/pl/project13/maven/git/NaivePerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/test/java/pl/project13/maven/git/log/MavenLoggerBridgeTest.java
+++ b/src/test/java/pl/project13/maven/git/log/MavenLoggerBridgeTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package pl.project13.maven.git.log;
 
 import org.junit.Test;

--- a/src/test/java/pl/project13/maven/git/log/StdOutLoggerBridgeTest.java
+++ b/src/test/java/pl/project13/maven/git/log/StdOutLoggerBridgeTest.java
@@ -1,3 +1,20 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package pl.project13.maven.git.log;
 
 import org.junit.Test;

--- a/src/test/java/pl/project13/test/utils/AssertException.java
+++ b/src/test/java/pl/project13/test/utils/AssertException.java
@@ -30,7 +30,6 @@ import static pl.project13.test.utils.AssertException.ExceptionMatch.EXCEPTION_C
  *
  * SoftwareBirr 02.2012
  *
- * @author Konrad Malawski (konrad.malawski@java.pl)
  * @see <a href="https://github.com/softwaremill/softwaremill-common/blob/master/softwaremill-test/softwaremill-test-util/src/main/java/pl/softwaremill/common/test/util/AssertException.java">AssertException in softwaremill-common/softwaremill-test-util</a>
  */
 public class AssertException {

--- a/src/test/java/pl/project13/test/utils/AssertException.java
+++ b/src/test/java/pl/project13/test/utils/AssertException.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of git-commit-id-plugin by Konrad Malawski <konrad.malawski@java.pl>
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
  *
  * git-commit-id-plugin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by


### PR DESCRIPTION
Hi @ktoso,
today I had some time to implement the feature for #54.
This PR looks huge but it isn't.
Most what I did was shifting code from DescribeCommand.java to a new class JGitCommon.java to make it easier accessible. This basically gave me the opportunity to reuse the major part of the functionality. We still could speed up the JGit-Implementation by saving the values we need twice but I leave this as optional :-9

Also I fixed the license-headers (some files had a duplicated license info) and added the new properties to the readme (I caught one that was missing...).

Let me know if I should improve something for the PR.

Thanks,