### PR TITLE
Fix for #204

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                     <!-- that's the default value -->
                     <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
 
+                    <!-- @since 2.1.16 -->
+                    <!-- 
+                         If you want to set the timezone of the dateformat to anything in particular you can do this by using this option. 
+                         As a general warning try to avoid three-letter time zone IDs because the same abbreviation are often used for multiple time zones. 
+                         The default value we'll use the timezone use the timezone that's shipped with java (java.util.TimeZone.getDefault().getID()). 
+                         *Note*: If you plan to set the java's timezone by using `MAVEN_OPTS=-Duser.timezone=UTC mvn clean package`, `mvn clean package -Duser.timezone=UTC` or any other configuration keep in mind that this option will override those settings and will not take other configurations into account!
+                    -->
+                    <dateFormatTimeZone>${user.timezone}</dateFormatTimeZone>
+
                     <!-- false is default here, it prints some more information during the build -->
                     <verbose>false</verbose>
 
@@ -631,6 +640,7 @@ Optional parameters:
 * **dotGitDirectory** - `(default: ${project.basedir}/.git)` the location of your .git folder. `${project.basedir}/.git` is the default value and will most probably be ok for single module projects, in other cases please use `../` to get higher up in the dir tree. An example would be: `${project.basedir}/../.git` which I'm currently using in my projects :-)
 * **prefix** - `(default: git)` is the "namespace" for all exposed properties
 * **dateFormat** - `(default: dd.MM.yyyy '@' HH:mm:ss z)` is a normal SimpleDateFormat String and will be used to represent git.build.time and git.commit.time
+* **dateFormatTimeZone** - `(default: empty)` *(available since v2.1.16)* is a TimeZone String (e.g. 'America/Los_Angeles', 'GMT+10', 'PST') and can be used to set the timezone of the *dateFormat* to anything in particular. As a general warning try to avoid three-letter time zone IDs because the same abbreviation are often used for multiple time zones. The default value we'll use the timezone use the timezone that's shipped with java (java.util.TimeZone.getDefault().getID()). *Note*: If you plan to set the java's timezone by using `MAVEN_OPTS=-Duser.timezone=UTC mvn clean package`, `mvn clean package -Duser.timezone=UTC` or any other configuration keep in mind that this option will override those settings and will not take other configurations into account!
 * **verbose** - `(default: false)` if true the plugin will print a summary of all collected properties when it's done
 * **generateGitPropertiesFile** -`(default: false)` this is false by default, forces the plugin to generate the git.properties file
 * **generateGitPropertiesFilename** - `(default: ${project.build.outputDirectory}/git.properties)` - The path for the to be generated properties file. The path can be relative to ${project.basedir} (e.g. target/classes/git.properties) or can be a full path (e.g. ${project.build.outputDirectory}/git.properties).

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                     <!-- that's the default value -->
                     <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
 
-                    <!-- @since 2.1.16 -->
+                    <!-- @since 2.2.0 -->
                     <!-- 
                          If you want to set the timezone of the dateformat to anything in particular you can do this by using this option. 
                          As a general warning try to avoid three-letter time zone IDs because the same abbreviation are often used for multiple time zones. 
@@ -640,7 +640,7 @@ Optional parameters:
 * **dotGitDirectory** - `(default: ${project.basedir}/.git)` the location of your .git folder. `${project.basedir}/.git` is the default value and will most probably be ok for single module projects, in other cases please use `../` to get higher up in the dir tree. An example would be: `${project.basedir}/../.git` which I'm currently using in my projects :-)
 * **prefix** - `(default: git)` is the "namespace" for all exposed properties
 * **dateFormat** - `(default: dd.MM.yyyy '@' HH:mm:ss z)` is a normal SimpleDateFormat String and will be used to represent git.build.time and git.commit.time
-* **dateFormatTimeZone** - `(default: empty)` *(available since v2.1.16)* is a TimeZone String (e.g. 'America/Los_Angeles', 'GMT+10', 'PST') and can be used to set the timezone of the *dateFormat* to anything in particular. As a general warning try to avoid three-letter time zone IDs because the same abbreviation are often used for multiple time zones. The default value we'll use the timezone use the timezone that's shipped with java (java.util.TimeZone.getDefault().getID()). *Note*: If you plan to set the java's timezone by using `MAVEN_OPTS=-Duser.timezone=UTC mvn clean package`, `mvn clean package -Duser.timezone=UTC` or any other configuration keep in mind that this option will override those settings and will not take other configurations into account!
+* **dateFormatTimeZone** - `(default: empty)` *(available since v2.2.0)* is a TimeZone String (e.g. 'America/Los_Angeles', 'GMT+10', 'PST') and can be used to set the timezone of the *dateFormat* to anything in particular. As a general warning try to avoid three-letter time zone IDs because the same abbreviation are often used for multiple time zones. The default value we'll use the timezone use the timezone that's shipped with java (java.util.TimeZone.getDefault().getID()). *Note*: If you plan to set the java's timezone by using `MAVEN_OPTS=-Duser.timezone=UTC mvn clean package`, `mvn clean package -Duser.timezone=UTC` or any other configuration keep in mind that this option will override those settings and will not take other configurations into account!
 * **verbose** - `(default: false)` if true the plugin will print a summary of all collected properties when it's done
 * **generateGitPropertiesFile** -`(default: false)` this is false by default, forces the plugin to generate the git.properties file
 * **generateGitPropertiesFilename** - `(default: ${project.build.outputDirectory}/git.properties)` - The path for the to be generated properties file. The path can be relative to ${project.basedir} (e.g. target/classes/git.properties) or can be a full path (e.g. ${project.build.outputDirectory}/git.properties).

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,7 @@
               <generateGitPropertiesFile>true</generateGitPropertiesFile>
               <generateGitPropertiesFilename>target/testing.properties</generateGitPropertiesFilename>
               <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
+              <dateFormatTimeZone>GMT-08:00</dateFormatTimeZone>
               <useNativeGit>false</useNativeGit>
               <abbrevLength>7</abbrevLength>
               <format>properties</format>

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
 
 /**
  * Goal which puts git build-time information into property files or maven's properties.
@@ -223,6 +224,20 @@ public class GitCommitIdMojo extends AbstractMojo {
    */
   @SuppressWarnings("UnusedDeclaration")
   private String dateFormat;
+
+  /**
+   * The timezone used in the date format that's used for any dates exported by this plugin.
+   * It should be a valid Timezone string (e.g. 'America/Los_Angeles', 'GMT+10', 'PST').
+   * As a general warning try to avoid three-letter time zone IDs because the same abbreviation are often used for multiple time zones.
+   * Please review https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html for more information on this issue.
+   * will use the timezone that's shipped with java as a default (java.util.TimeZone.getDefault().getID())
+   * 
+   * @parameter
+   */
+  @SuppressWarnings("UnusedDeclaration")
+  private String dateFormatTimeZone;
+
+
 
   /**
    * Specifies whether the plugin should fail if it can't find the .git directory. The default
@@ -516,6 +531,9 @@ public class GitCommitIdMojo extends AbstractMojo {
   void loadBuildVersionAndTimeData(@NotNull Properties properties) {
     Date buildDate = new Date();
     SimpleDateFormat smf = new SimpleDateFormat(dateFormat);
+    if(dateFormatTimeZone != null){
+      smf.setTimeZone(TimeZone.getTimeZone(dateFormatTimeZone));
+    }
     put(properties, BUILD_TIME, smf.format(buildDate));
     put(properties, BUILD_VERSION, project.getVersion());
   }
@@ -568,6 +586,7 @@ public class GitCommitIdMojo extends AbstractMojo {
       .setPrefixDot(prefixDot)
       .setAbbrevLength(abbrevLength)
       .setDateFormat(dateFormat)
+      .setDateFormatTimeZone(dateFormatTimeZone)
       .setGitDescribe(gitDescribe);
 
     nativeGitProvider.loadGitData(properties);
@@ -580,6 +599,7 @@ public class GitCommitIdMojo extends AbstractMojo {
       .setPrefixDot(prefixDot)
       .setAbbrevLength(abbrevLength)
       .setDateFormat(dateFormat)
+      .setDateFormatTimeZone(dateFormatTimeZone)
       .setGitDescribe(gitDescribe);
 
     jGitProvider.loadGitData(properties);

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -25,6 +25,8 @@ import pl.project13.maven.git.util.PropertyManager;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
+import java.text.SimpleDateFormat;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -40,6 +42,8 @@ public abstract class GitDataProvider {
   protected int abbrevLength;
 
   protected String dateFormat;
+
+  protected String dateFormatTimeZone;
 
   protected GitDescribeConfig gitDescribe = new GitDescribeConfig();
 
@@ -64,6 +68,11 @@ public abstract class GitDataProvider {
 
   public GitDataProvider setDateFormat(String dateFormat) {
     this.dateFormat = dateFormat;
+    return this;
+  }
+
+  public GitDataProvider setDateFormatTimeZone(String dateFormatTimeZone){
+    this.dateFormatTimeZone = dateFormatTimeZone;
     return this;
   }
 
@@ -188,6 +197,14 @@ public abstract class GitDataProvider {
       log("Using environment variable based branch name.", "GIT_BRANCH =", enviromentBasedBranch);
       return enviromentBasedBranch;
     }
+  }
+
+  protected SimpleDateFormat getSimpleDateFormatWithTimeZone(){
+    SimpleDateFormat smf = new SimpleDateFormat(dateFormat);
+    if(dateFormatTimeZone != null){
+      smf.setTimeZone(TimeZone.getTimeZone(dateFormatTimeZone));
+    }
+    return smf;
   }
 
   void log(String... parts) {

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -176,7 +176,7 @@ public class JGitProvider extends GitDataProvider {
   protected String getCommitTime() {
     long timeSinceEpoch = headCommit.getCommitTime();
     Date commitDate = new Date(timeSinceEpoch * 1000); // git is "by sec" and java is "by ms"
-    SimpleDateFormat smf = new SimpleDateFormat(dateFormat);
+    SimpleDateFormat smf = getSimpleDateFormatWithTimeZone();
     return smf.format(commitDate);
   }
 

--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -206,7 +206,7 @@ public class NativeGitProvider extends GitDataProvider {
   @Override
   protected String getCommitTime() {
     String value =  runQuietGitCommand(canonical, "log -1 --pretty=format:%ct");
-    SimpleDateFormat smf = new SimpleDateFormat(dateFormat);
+    SimpleDateFormat smf = getSimpleDateFormatWithTimeZone();
     return smf.format(Long.parseLong(value)*1000L);
   }
 


### PR DESCRIPTION
As described in https://github.com/ktoso/maven-git-commit-id-plugin/issues/204 added the ability to set the timezone along with dateFormat.

I hopefully made it crystal clear in the docs that setting the timeZone in the plugin's configuration will override any other configuration.
The reason for this, is that we can not determine at which level the user has altered the timezone of java or the system. It could be in some configuration file or by setting runtime environment parameters like ``-Duser.timezone=UTC``. If we investigate the system properties of java, we only see the latest version that was set. At this moment java does not simply ship an option to determine where the timezone was altered. Also I didn't want to introduce some garbage code that invokes a process builder that asks for the `real timezone` (or some other magic code that is system dependant).