### PR TITLE
#211 : add a switch to generate the git.commit.id the "old" way

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ Migration Issues you may come across when using the latest 2.2.X
 -----------------------------
 If you are already using the git-commit-id-plugin and would like to move to the latest major release (2.2.X) there are some design choices we made to fix some of your issues.
 1. We dropped the support of Java 1.6 (if you still rely on this version, the version 2.1.15 still has support for this and you may want to check the fixed issues since then before reporting a new one)
-2. We renamed git.commit.id to git.commit.id.full to enable full compability with json (see https://github.com/ktoso/maven-git-commit-id-plugin/issues/122)
+2. Due to some naming issues when exporting the properties as an json-object (https://github.com/ktoso/maven-git-commit-id-plugin/issues/122) we needed to change the export of the property from 'git.commit.id' to 'git.commit.id.full'.
+   However, due to the fact that this is one of the major properties the plugin is exporting we just don't want to change the exporting mechanism and somehow throw the backwards compatibility away we introduced a switch called 'generateCommitIdOldFashioned'.
+   By default it is set to 'true' and will generate the formerly known property 'git.commit.id' as it was in the previous versions of the plugin. With keeping the switch set to 'true' the plugin will print a warning that using this switch set to 'true' is deprecated and may be removed in a future release. However keeping it to 'true' by default preserve backwards compatibility and allows to migrate to the new properties when it's convenient.
+   If you set this switch to 'false' the plugin will export the formerly known property 'git.commit.id' as 'git.commit.id.full'.
 
-I think especially the second one will strike all of our users and we really would like to apologize for any inconvenience :-)
+   *Note*: Depending on your plugin configuration you obviously can choose the 'prefix' of your properties by setting it accordingly in the plugin's configuration. As a result this is therefore only an illustration what the switch means when the 'prefix' is set to it's default value.
+
 
 Getting SNAPSHOT versions of the plugin
 ---------------------------------------

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Migration Issues you may come across when using the latest 2.2.X
 If you are already using the git-commit-id-plugin and would like to move to the latest major release (2.2.X) there are some design choices we made to fix some of your issues.
 1. We dropped the support of Java 1.6 (if you still rely on this version, the version 2.1.15 still has support for this and you may want to check the fixed issues since then before reporting a new one)
 2. Due to some naming issues when exporting the properties as an json-object (https://github.com/ktoso/maven-git-commit-id-plugin/issues/122) we needed to change the export of the property from 'git.commit.id' to 'git.commit.id.full'.
-   However, due to the fact that this is one of the major properties the plugin is exporting we just don't want to change the exporting mechanism and somehow throw the backwards compatibility away we introduced a switch called 'generateCommitIdOldFashioned'.
+   However, due to the fact that this is one of the major properties the plugin is exporting we just don't want to change the exporting mechanism and somehow throw the backwards compatibility away.
+   To overcome this issue we introduced a switch called 'generateCommitIdOldFashioned'.
    By default it is set to 'true' and will generate the formerly known property 'git.commit.id' as it was in the previous versions of the plugin. With keeping the switch set to 'true' the plugin will print a warning that using this switch set to 'true' is deprecated and may be removed in a future release. However keeping it to 'true' by default preserve backwards compatibility and allows to migrate to the new properties when it's convenient.
    If you set this switch to 'false' the plugin will export the formerly known property 'git.commit.id' as 'git.commit.id.full'.
 

--- a/src/main/java/pl/project13/maven/git/CommitIdGenerationModeEnum.java
+++ b/src/main/java/pl/project13/maven/git/CommitIdGenerationModeEnum.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of git-commit-id-plugin by Konrad 'ktoso' Malawski <konrad.malawski@java.pl>
+ *
+ * git-commit-id-plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * git-commit-id-plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with git-commit-id-plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package pl.project13.maven.git;
+
+public enum CommitIdGenerationModeEnum{
+  FULL,
+  FLAT,
+  UNKNOWN;
+	
+  public static CommitIdGenerationModeEnum getValue(String o){
+    if(o != null){
+      for(CommitIdGenerationModeEnum v : values()){
+        if(v.name().toString().equalsIgnoreCase(o)){
+          return v;
+        }
+      }
+    }
+    return CommitIdGenerationModeEnum.UNKNOWN;
+  }	
+}

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -404,16 +404,13 @@ public class GitCommitIdMojo extends AbstractMojo {
     }
 
     try {
-      if(commitIdGenerationMode == null){
-        commitIdGenerationMode = "flat";
-      }
-      switch(commitIdGenerationMode.toLowerCase()){
+      switch(CommitIdGenerationModeEnum.getValue(commitIdGenerationMode)){
       default:
         loggerBridge.warn("Detected wrong setting for 'commitIdGenerationMode' will fallback to default 'flat'-Mode!");
-      case "flat":
+      case FLAT:
         COMMIT_ID = COMMIT_ID_FLAT;
         break;
-      case "full":
+      case FULL:
         COMMIT_ID = COMMIT_ID_FULL;
         break;
       }

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -336,9 +336,9 @@ public class GitCommitIdMojo extends AbstractMojo {
    * However, due to the fact that this is one of the major properties the plugin is exporting we just don't want to change the exporting mechanism and somehow throw the backwards compatibility away.
    * That's the point where this switch comes into place!
    * By default it is set to 'true' and will generate the formerly known property 'git.commit.id' as it was in the previous versions of the plugin. With keeping the switch set to 'true' the plugin will print a warning that using this switch set to 'true' is deprecated and may be removed in a future release. However keeping it to 'true' by default preserve backwards compatibility and allows to migrate to the new properties when it's convenient.
-   * If you set this switch to 'false' the plugin will export the formerly known property 'git.commit.id' to 'git.commit.id.full'.
+   * If you set this switch to 'false' the plugin will export the formerly known property 'git.commit.id' as 'git.commit.id.full'.
    *
-   * Note: Depending on your plugin configuration you obviously can choose the 'prefix' of your properties by setting the accordingly in the plugin's configuration. As a result this is therefore only an illustration what the switch means when 'prefix' is set to it's default value.
+   * *Note*: Depending on your plugin configuration you obviously can choose the 'prefix' of your properties by setting it accordingly in the plugin's configuration. As a result this is therefore only an illustration what the switch means when the 'prefix' is set to it's default value.
    *
    * @parameter default-value="true"
    * @since 2.2.0

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -66,7 +66,11 @@ public class GitCommitIdMojo extends AbstractMojo {
   // these properties will be exposed to maven
   public static final String BRANCH = "branch";
   public static final String DIRTY = "dirty";
-  public static final String COMMIT_ID = "commit.id.full";
+  @Deprecated
+  public static final String COMMIT_ID_OLD = "commit.id";
+  public static final String COMMIT_ID_NEW = "commit.id.full";
+  public static String COMMIT_ID = COMMIT_ID_NEW;
+
   public static final String COMMIT_ID_ABBREV = "commit.id.abbrev";
   public static final String COMMIT_DESCRIBE = "commit.id.describe";
   public static final String COMMIT_SHORT_DESCRIBE = "commit.id.describe-short";
@@ -328,6 +332,21 @@ public class GitCommitIdMojo extends AbstractMojo {
   private List<String> includeOnlyProperties = Collections.emptyList();
 
   /**
+   * The option can be used to tell the plugin how it should generate the formerly known property 'git.commit.id'. Due to some naming issues when exporting the properties as an json-object (https://github.com/ktoso/maven-git-commit-id-plugin/issues/122) we needed to change the export of the property from 'git.commit.id' to 'git.commit.id.full'.
+   * However, due to the fact that this is one of the major properties the plugin is exporting we just don't want to change the exporting mechanism and somehow throw the backwards compatibility away.
+   * That's the point where this switch comes into place!
+   * By default it is set to 'true' and will generate the formerly known property 'git.commit.id' as it was in the previous versions of the plugin. With keeping the switch set to 'true' the plugin will print a warning that using this switch set to 'true' is deprecated and may be removed in a future release. However keeping it to 'true' by default preserve backwards compatibility and allows to migrate to the new properties when it's convenient.
+   * If you set this switch to 'false' the plugin will export the formerly known property 'git.commit.id' to 'git.commit.id.full'.
+   *
+   * Note: Depending on your plugin configuration you obviously can choose the 'prefix' of your properties by setting the accordingly in the plugin's configuration. As a result this is therefore only an illustration what the switch means when 'prefix' is set to it's default value.
+   *
+   * @parameter default-value="true"
+   * @since 2.2.0
+   */
+  @Deprecated
+  private boolean generateCommitIdOldFashioned;
+
+  /**
    * The Maven Session Object
    *
    * @parameter property="session"
@@ -383,6 +402,15 @@ public class GitCommitIdMojo extends AbstractMojo {
     }
 
     try {
+      if(generateCommitIdOldFashioned){
+        loggerBridge.warn("Using the property 'generateCommitIdOldFashioned' set to 'true' is deprecated and may be removed in a future release! Please refer to the readme on this issue.");
+        COMMIT_ID = COMMIT_ID_OLD;
+      }else{
+        // need to have this for the tests due the fact that they are switching back and forth
+        // for the end-user setting this shouldn't perform any changes (it's set to COMMIT_ID_NEW by default)
+        COMMIT_ID = COMMIT_ID_NEW;
+      }
+
       properties = initProperties();
 
       String trimmedPrefix = prefix.trim();

--- a/src/main/java/pl/project13/maven/git/log/LoggerBridge.java
+++ b/src/main/java/pl/project13/maven/git/log/LoggerBridge.java
@@ -20,6 +20,7 @@ package pl.project13.maven.git.log;
 public interface LoggerBridge {
   void log(Object... parts);
   void error(Object... parts);
+  void warn(Object... parts);
   void debug(Object... parts);
   void setVerbose(boolean verbose);
 }

--- a/src/main/java/pl/project13/maven/git/log/MavenLoggerBridge.java
+++ b/src/main/java/pl/project13/maven/git/log/MavenLoggerBridge.java
@@ -62,6 +62,13 @@ public class MavenLoggerBridge implements LoggerBridge {
   }
 
   @Override
+  public void warn(Object... parts) {
+    if (verbose) {
+      logger.warn(Joiner.on(" ").useForNull("null").join(parts));
+    }
+  }
+
+  @Override
   public void debug(Object... parts) {
     if (verbose) {
       logger.debug(Joiner.on(" ").useForNull("null").join(parts));

--- a/src/main/java/pl/project13/maven/git/log/StdOutLoggerBridge.java
+++ b/src/main/java/pl/project13/maven/git/log/StdOutLoggerBridge.java
@@ -40,6 +40,13 @@ public class StdOutLoggerBridge implements LoggerBridge {
       System.out.println("ERR: " + Joiner.on(" ").join(parts));
     }
   }
+
+  @Override
+  public void warn(Object... parts) {
+    if(verbose) {
+      System.out.println("WRN: " + Joiner.on(" ").join(parts));
+    }
+  }
   
   @Override
   public void debug(Object... parts) {

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -792,6 +792,30 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     TimeZone.setDefault(currentDefaultTimeZone);
   }
 
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldGenerateCommitIdOldFashioned(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-pom-project", "pom")
+                .withChildProject("my-jar-module", "jar")
+                .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG_DIRTY)
+                .create(CleanUp.CLEANUP_FIRST);
+    MavenProject targetProject = mavenSandbox.getChildProject();
+
+    setProjectToExecuteMojoIn(targetProject);
+
+    alterMojoSettings("useNativeGit", useNativeGit);
+    alterMojoSettings("generateCommitIdOldFashioned", true);
+
+    // when
+    mojo.execute();
+
+    // then
+    Properties properties = targetProject.getProperties();
+    assertThat(properties.stringPropertyNames()).contains("git.commit.id");
+    assertThat(properties.stringPropertyNames()).excludes("git.commit.id.full");
+  }
+
   private GitDescribeConfig createGitDescribeConfig(boolean forceLongFormat, int abbrev) {
     GitDescribeConfig gitDescribeConfig = new GitDescribeConfig();
     gitDescribeConfig.setTags(true);

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -805,7 +805,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     setProjectToExecuteMojoIn(targetProject);
 
     alterMojoSettings("useNativeGit", useNativeGit);
-    alterMojoSettings("generateCommitIdOldFashioned", true);
+    alterMojoSettings("commitIdGenerationMode", "flat");
 
     // when
     mojo.execute();

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -61,6 +61,7 @@ public class GitCommitIdMojoTest {
     mojo.setVerbose(true);
     mojo.useNativeGit(false);
     mojo.setGitDescribe(gitDescribeConfig);
+    mojo.setCommitIdGenerationMode("full");
 
 
     mojo.runningTests = true;

--- a/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
@@ -76,6 +76,7 @@ public abstract class GitIntegrationTest {
     mojoDefaults.put("dateFormat", "dd.MM.yyyy '@' HH:mm:ss z");
     mojoDefaults.put("failOnNoGitDirectory", true);
     mojoDefaults.put("useNativeGit", false);
+    mojoDefaults.put("generateCommitIdOldFashioned", false);
     for (Map.Entry<String, Object> entry : mojoDefaults.entrySet()) {
       setInternalState(mojo, entry.getKey(), entry.getValue());
     }

--- a/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
@@ -76,7 +76,7 @@ public abstract class GitIntegrationTest {
     mojoDefaults.put("dateFormat", "dd.MM.yyyy '@' HH:mm:ss z");
     mojoDefaults.put("failOnNoGitDirectory", true);
     mojoDefaults.put("useNativeGit", false);
-    mojoDefaults.put("generateCommitIdOldFashioned", false);
+    mojoDefaults.put("commitIdGenerationMode", "full");
     for (Map.Entry<String, Object> entry : mojoDefaults.entrySet()) {
       setInternalState(mojo, entry.getKey(), entry.getValue());
     }


### PR DESCRIPTION
As outlined in #211 I think this is much better for the generation "git.commit.id" VS "git.commit.id.full".
Have tested with different options and build in parallel (mvn -T 4 clean package -Pdemo -Dmaven.test.skip=true) nothing special discovered.