### PR TITLE
properties: add git.dirty.mark property

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -66,6 +66,7 @@ public class GitCommitIdMojo extends AbstractMojo {
   // these properties will be exposed to maven
   public static final String BRANCH = "branch";
   public static final String DIRTY = "dirty";
+  public static final String DIRTY_MARK = "dirty.mark";
   public static final String COMMIT_ID_FLAT = "commit.id";
   public static final String COMMIT_ID_FULL = "commit.id.full";
   public static String COMMIT_ID = COMMIT_ID_FLAT;
@@ -234,7 +235,7 @@ public class GitCommitIdMojo extends AbstractMojo {
    * As a general warning try to avoid three-letter time zone IDs because the same abbreviation are often used for multiple time zones.
    * Please review https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html for more information on this issue.
    * will use the timezone that's shipped with java as a default (java.util.TimeZone.getDefault().getID())
-   * 
+   *
    * @parameter
    */
   @SuppressWarnings("UnusedDeclaration")

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -113,10 +113,12 @@ public abstract class GitDataProvider {
       maybePutGitDescribe(properties);
       // git.commit.id
       put(properties, GitCommitIdMojo.COMMIT_ID, getCommitId());
-      // git.commit.id.abbrev      
+      // git.commit.id.abbrev
       put(properties, GitCommitIdMojo.COMMIT_ID_ABBREV, getAbbrevCommitId());
       // git.dirty
       put(properties, GitCommitIdMojo.DIRTY, Boolean.toString(isDirty()));
+      // git.dirty.mark
+      put(properties, GitCommitIdMojo.DIRTY_MARK, getDirtyMark());
       // git.commit.author.name
       put(properties, GitCommitIdMojo.COMMIT_AUTHOR_NAME, getCommitAuthorName());
       // git.commit.author.email
@@ -132,7 +134,7 @@ public abstract class GitDataProvider {
 
       //
       put(properties, GitCommitIdMojo.TAGS, getTags());
-      
+
       put(properties,GitCommitIdMojo.CLOSEST_TAG_NAME, getClosestTagName());
       put(properties,GitCommitIdMojo.CLOSEST_TAG_COMMIT_COUNT, getClosestTagCommitCount());
     } finally {
@@ -147,6 +149,17 @@ public abstract class GitDataProvider {
     if (isGitDescribeOptOutByDefault || isGitDescribeOptOutByConfiguration) {
       put(properties, GitCommitIdMojo.COMMIT_DESCRIBE, getGitDescribe());
     }
+  }
+
+  private String getDirtyMark() throws MojoExecutionException
+  {
+      String dirtyMark = gitDescribe.getDirty();
+
+      if (dirtyMark != null && !dirtyMark.isEmpty() && isDirty()) {
+          return dirtyMark;
+      } else {
+          return "";
+      }
   }
 
   void validateAbbrevLength(int abbrevLength) throws MojoExecutionException {


### PR DESCRIPTION
Motivation:

Easily include the dirty status in other maven properties, in the format
described by the 'dirty' configuration property.

Modification:

An additional property is exposed to maven: 'git.dirty.mark'.  If the
code-base has non-checked-in changes then the 'git.dirty.mark' property
value is the configured dirty mark, as used in 'git.commit.id.describe'.
If the code-base is clean then 'git.dirty.mark' expands to the empty
string.

Result:

Whether the code-base is clean or dirty is easily available in the
configured format.