### PR TITLE
Closest tag function return incorrect value. Fixed comparator

### DIFF
--- a/src/main/java/pl/project13/jgit/JGitCommon.java
+++ b/src/main/java/pl/project13/jgit/JGitCommon.java
@@ -17,8 +17,24 @@
 
 package pl.project13.jgit;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Maps.newHashMap;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.jetbrains.annotations.NotNull;
+import pl.project13.jgit.dummy.DatedRevTag;
+import pl.project13.maven.git.log.LoggerBridge;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -32,27 +48,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.regex.Pattern;
-
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.errors.IncorrectObjectTypeException;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.revwalk.RevTag;
-import org.eclipse.jgit.revwalk.RevWalk;
-import org.jetbrains.annotations.NotNull;
-
-import pl.project13.jgit.dummy.DatedRevTag;
-import pl.project13.maven.git.log.LoggerBridge;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Lists.newLinkedList;
@@ -256,7 +251,7 @@ public class JGitCommon {
     return new Comparator<DatedRevTag>() {
         @Override
         public int compare(DatedRevTag revTag, DatedRevTag revTag2) {
-          return revTag2.date.compareTo(revTag.date);
+          return revTag.date.compareTo(revTag2.date);
         }
       };
   }


### PR DESCRIPTION
The issue is related to the closes tag.

For example we have tags like
1(01.01.2015)             2(10.01.2015)     3(20.01.2015)                      4(30.01.2015)

when specify option in maven plugin vcs.closest.tag.name it return the first 1 but I expect to the 4 instead of 1.

Could you please review the fix or let me know if I am wrong.

Thanks in advance.