### PR TITLE
Support GIT_LOCAL_BRANCH in Jenkins / Hudson

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -204,18 +204,24 @@ public abstract class GitDataProvider {
   }
 
   /**
-   * Is "Jenkins aware", and prefers {@code GIT_BRANCH} to getting the branch via git if that environment variable is set.
-   * The {@code GIT_BRANCH} variable is set by Jenkins/Hudson when put in detached HEAD state, but it still knows which branch was cloned.
+   * Is "Jenkins aware", and prefers {@code GIT_LOCAL_BRANCH} over {@code GIT_BRANCH} to getting the branch via git if that environment variables are set.
+   * The {@code GIT_LOCAL_BRANCH} and {@code GIT_BRANCH} variables are set by Jenkins/Hudson when put in detached HEAD state, but it still knows which branch was cloned.
    */
   protected String determineBranchNameOnBuildServer(Map<String, String> env) throws GitCommitIdExecutionException {
+    String environmentBasedLocalBranch = env.get("GIT_LOCAL_BRANCH");
+    if(!isNullOrEmpty(environmentBasedLocalBranch)){
+      log.info("Using environment variable based branch name. GIT_LOCAL_BRANCH = {}", environmentBasedLocalBranch);
+      return environmentBasedLocalBranch;
+    }
+
     String environmentBasedBranch = env.get("GIT_BRANCH");
-    if (isNullOrEmpty(environmentBasedBranch)) {
-      log.info("Detected that running on CI environment, but using repository branch, no GIT_BRANCH detected.");
-      return getBranchName();
-    } else {
+    if (!isNullOrEmpty(environmentBasedBranch)) {
       log.info("Using environment variable based branch name. GIT_BRANCH = {}", environmentBasedBranch);
       return environmentBasedBranch;
     }
+
+    log.info("Detected that running on CI environment, but using repository branch, no GIT_BRANCH detected.");
+    return getBranchName();
   }
 
   protected SimpleDateFormat getSimpleDateFormatWithTimeZone(){

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -248,9 +248,24 @@ public class GitCommitIdMojoTest {
     env.put("HUDSON_URL", ciUrl);
     assertThat("mybranch").isEqualTo(jGitProvider.determineBranchName(env));
 
+    // now set GIT_LOCAL_BRANCH too and see that the branch name from env var is returned
+    env.clear();
+    env.put("JENKINS_URL", ciUrl);
+    env.put("GIT_BRANCH", "mybranch");
+    env.put("GIT_LOCAL_BRANCH", "mylocalbranch");
+    assertThat("mylocalbranch").isEqualTo(jGitProvider.determineBranchName(env));
+
+    // same, but for hudson
+    env.clear();
+    env.put("GIT_BRANCH", "mybranch");
+    env.put("GIT_LOCAL_BRANCH", "mylocalbranch");
+    env.put("HUDSON_URL", ciUrl);
+    assertThat("mylocalbranch").isEqualTo(jGitProvider.determineBranchName(env));
+
     // GIT_BRANCH but no HUDSON_URL or JENKINS_URL
     env.clear();
     env.put("GIT_BRANCH", "mybranch");
+    env.put("GIT_BRANCH", "mylocalbranch");
     assertThat(detachedHeadSHA1).isEqualTo(jGitProvider.determineBranchName(env));
   }
   


### PR DESCRIPTION
The current release version of the maven-git-commit-id-plugin resolves the branch name from GIT_BRANCH if it detects a Jenkins / Hudson environment.
 
In version 2.4.3 of the Git Plugin for Jenkins / Hudson support for deriving local branch names from remote branch names was added. The name for the derived local branch is exposed in the GIT_LOCAL_BRANCH environment variable.

https://issues.jenkins-ci.org/browse/JENKINS-33202
https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin

The changes in this pull request should add support for the new derived local branch.

