### PR TITLE
Fix support the always flag for the describe command in JGit in shallow clones

### DIFF
--- a/src/main/java/pl/project13/jgit/DescribeCommand.java
+++ b/src/main/java/pl/project13/jgit/DescribeCommand.java
@@ -273,7 +273,17 @@ public class DescribeCommand extends GitCommand<DescribeResult> {
     }
 
     // get commits, up until the nearest tag
-    List<RevCommit> commits = jGitCommon.findCommitsUntilSomeTag(repo, headCommit, tagObjectIdToName);
+    List<RevCommit> commits;
+    try {
+      commits = jGitCommon.findCommitsUntilSomeTag(repo, headCommit, tagObjectIdToName);
+    } catch(Exception e) {
+      if (alwaysFlag) {
+        // Show uniquely abbreviated commit object as fallback
+        commits = Collections.emptyList();
+      } else {
+        throw e;
+      }
+    }
 
     // if there is no tags or any tag is not on that branch then return generic describe
     if (foundZeroTags(tagObjectIdToName) || commits.isEmpty()) {


### PR DESCRIPTION
If an exception occurs while getting the commits in the JGit describe command implementation, and the always flag is set, show the uniquely abbreviated commit object as fallback matching the native git command's behavior.

This change fixes #61 

To see this issue, run this plugin against a shallow clone (`git clone --depth 1`) that has multiple commits with the configuration of this plugin having:
```xml
<configuration>
  <gitDescribe>
    <always>true</always>
  </gitDescribe>
</configuration>
```

Before this change, this exception occurs:
```
[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:2.2.2:revision (default) on project mindsight: Could not complete Mojo execution... Unable to find commits until some tag: Walk failure. Missing commit a5bb6881b545cbcd0f54b6decfc2b1a41ca85279 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal pl.project13.maven:git-commit-id-plugin:2.2.2:revision (default) on project mindsight: Could not complete Mojo execution...
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: Could not complete Mojo execution...
	at pl.project13.maven.git.GitCommitIdMojo.execute(GitCommitIdMojo.java:402)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	... 20 more
Caused by: pl.project13.maven.git.GitCommitIdExecutionException: Could not complete Mojo execution...
	at pl.project13.maven.git.GitCommitIdMojo.handlePluginFailure(GitCommitIdMojo.java:465)
	at pl.project13.maven.git.GitCommitIdMojo.execute(GitCommitIdMojo.java:399)
	... 22 more
Caused by: java.lang.RuntimeException: Unable to find commits until some tag
	at pl.project13.jgit.JGitCommon.findCommitsUntilSomeTag(JGitCommon.java:269)
	at pl.project13.jgit.DescribeCommand.call(DescribeCommand.java:276)
	at pl.project13.maven.git.JGitProvider.getGitDescribe(JGitProvider.java:219)
	at pl.project13.maven.git.JGitProvider.getGitDescribe(JGitProvider.java:116)
	at pl.project13.maven.git.GitDataProvider.maybePutGitDescribe(GitDataProvider.java:167)
	at pl.project13.maven.git.GitDataProvider.loadGitData(GitDataProvider.java:120)
	at pl.project13.maven.git.GitCommitIdMojo.loadGitDataWithJGit(GitCommitIdMojo.java:595)
	at pl.project13.maven.git.GitCommitIdMojo.loadGitData(GitCommitIdMojo.java:562)
	at pl.project13.maven.git.GitCommitIdMojo.execute(GitCommitIdMojo.java:383)
	... 22 more
Caused by: org.eclipse.jgit.errors.RevWalkException: Walk failure.
	at org.eclipse.jgit.revwalk.RevWalk.iterator(RevWalk.java:1331)
	at pl.project13.jgit.JGitCommon.findCommitsUntilSomeTag(JGitCommon.java:257)
	... 30 more
Caused by: org.eclipse.jgit.errors.MissingObjectException: Missing commit a5bb6881b545cbcd0f54b6decfc2b1a41ca85279
	at org.eclipse.jgit.internal.storage.file.WindowCursor.open(WindowCursor.java:164)
	at org.eclipse.jgit.revwalk.RevWalk.getCachedBytes(RevWalk.java:903)
	at org.eclipse.jgit.revwalk.RevCommit.parseHeaders(RevCommit.java:155)
	at org.eclipse.jgit.revwalk.PendingGenerator.next(PendingGenerator.java:147)
	at org.eclipse.jgit.revwalk.StartGenerator.next(StartGenerator.java:184)
	at org.eclipse.jgit.revwalk.RevWalk.next(RevWalk.java:435)
	at org.eclipse.jgit.revwalk.RevWalk.iterator(RevWalk.java:1329)
	... 31 more
``