### PR TITLE
Support Maven 3.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,30 @@ jdk:
   - oraclejdk9
   - oraclejdk8
   - openjdk7
+
+matrix:
+  include:
+  - jdk: openjdk7
+    env: CUSTOM_MVN_VERION="3.0"
+  - jdk: openjdk7
+    env: CUSTOM_MVN_VERION="3.1.1"
+  - jdk: openjdk7
+    env: CUSTOM_MVN_VERION="3.2.5"
+  - jdk: openjdk7
+    env: CUSTOM_MVN_VERION="3.3.9"
+  - jdk: oraclejdk9
+    env: CUSTOM_MVN_VERION="3.5.0"
+
+install:
+  - if [[ -n "${CUSTOM_MVN_VERION}" ]]; then
+      echo "Download Maven ${CUSTOM_MVN_VERION}....";
+      if [[ "${CUSTOM_MVN_VERION}" == "3.0" ]]; then
+        wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1;
+      else
+        wget https://archive.apache.org/dist/maven/maven-3/${CUSTOM_MVN_VERION}/binaries/apache-maven-${CUSTOM_MVN_VERION}-bin.zip || travis_terminate 1;
+      fi;
+      unzip -qq apache-maven-${CUSTOM_MVN_VERION}-bin.zip || travis_terminate 1;
+      export M2_HOME=$PWD/apache-maven-${CUSTOM_MVN_VERION};
+      export PATH=$M2_HOME/bin:$PATH;
+      mvn -version;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
   - jdk: openjdk7
     env: CUSTOM_MVN_VERION="3.0"
   - jdk: openjdk7
+    env: CUSTOM_MVN_VERION="3.0.5"
+  - jdk: openjdk7
     env: CUSTOM_MVN_VERION="3.1.1"
   - jdk: openjdk7
     env: CUSTOM_MVN_VERION="3.2.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,8 @@ install:
       export PATH=$M2_HOME/bin:$PATH;
       mvn -version;
     fi
+
+script:
+  - mvn clean test install -B
+  - mvn clean initialize -Pdemo -Dmaven.test.skip=true -B
+  - /bin/bash -c '[[ -f target/testing.properties ]] && cat target/testing.properties || travis_terminate 1;'

--- a/README.md
+++ b/README.md
@@ -120,12 +120,13 @@ Plugin compatibility with maven
 -----------------------------
 Even though this plugin tries to be compatible with every Maven version there are some known limitations with specific versions. Here is a list that tries to outline the current state of the art:
 
-| Maven Version               | Plugin Version  | Notes                              |
-| --------------------------- | ---------------:|:----------------------------------:|
-| Maven 3.1.0 (and below)     | up to 2.1.13    |                                    |
-| Maven 3.1.1 (and onwards)   |          any    |                                    |
-| Maven 3.3.1                 |          any    | plugin version 2.1.14 doesn't work |
-| Maven 3.3.3                 |          any    | plugin version 2.1.14 doesn't work |
+| Maven Version               | Plugin Version  | Notes                                                                           |
+| --------------------------- | ---------------:|:-------------------------------------------------------------------------------:|
+| Maven 3.1.0 (and below)     | up to 2.1.13    |                                                                                 |
+| Maven 3.1.1 (and onwards)   |          any    |                                                                                 |
+| Maven 3.0   (and onwards)   |   from 2.2.4    | With Maven 3.0.X SLF4J fails to load class "org.slf4j.impl.StaticLoggerBinder". |
+| Maven 3.3.1                 |          any    | plugin version 2.1.14 doesn't work                                              |
+| Maven 3.3.3                 |          any    | plugin version 2.1.14 doesn't work                                              |
 
 
 Starting with Maven 3.1.1 any plugin version is currently compatible. Only known exception is for Maven 3.3.1 and Maven 3.3.3 where the plugin version 2.1.14 is not working properly.

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <java.target>1.7</java.target>
 
-    <maven-plugin-api.version>3.1.1</maven-plugin-api.version>
+    <maven-plugin-api.version>3.0</maven-plugin-api.version>
     <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
 
     <jgit.version>4.5.2.201704071617-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <java.target>1.7</java.target>
 
     <maven-plugin-api.version>3.0</maven-plugin-api.version>
-    <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
+    <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
 
     <jgit.version>4.5.2.201704071617-r</jgit.version>
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
This Refs to https://github.com/ktoso/maven-git-commit-id-plugin/issues/316
Local tests with
```
#!/bin/bash
for mavenBasePath in /usr/share/maven-3*
do
  echo "============================================"
  ${mavenBasePath}/bin/mvn --version
  echo ""
  # ${file}/bin/mvn clean initialize -Pdemo
  for pluginVersion in 2.2.4-SNAPSHOT
  do
    rm -rf target
    # echo ${pluginVersion}
    echo "${mavenBasePath}/bin/mvn pl.project13.maven:git-commit-id-plugin:${pluginVersion}:revision"
    ${mavenBasePath}/bin/mvn pl.project13.maven:git-commit-id-plugin:${pluginVersion}:revision -Pdemo > /dev/null
    rc=$?;
    if [[ $rc != 0 ]]; then
      echo "pl.project13.maven:git-commit-id-plugin:${pluginVersion} is NOT compatible";
    else
      echo "pl.project13.maven:git-commit-id-plugin:${pluginVersion} is compatible"
    fi

    echo ""
    cat target/testing.properties | sed 's/\(.*\)/  \1/'
  done
done
```
didn't yield any execution problems.
However for older Maven-Versions (3.0.X) there is a warning from SLF4J:
```
[INFO] --- git-commit-id-plugin:2.2.4-SNAPSHOT:revision (get-the-git-infos) @ git-commit-id-plugin ---
[INFO] dotGitDirectory /home/stefan/workspace/maven-git-commit-id-plugin/.git
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
This does not seem to impact the execution of the plugin and thus will be a known issue.

Also this updates the travis-build in a way that
- java 7, 8, 9 is being tested (as previously)
- plugin is being build with maven versions 3.0, 3.1.1, 3.2.5, 3.3.9 and 3.5.0

I would not add tests for any other minor versions to keep the builds to a somewhat minimum.