### PR TITLE
Adressing #337, #338, #339 and other minor improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--- Please follow the instructions below -->
+
+<!--- Provide a brief summary of the issue in the title above -->
+
+### Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+### Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+
+
+<!-- The following needs to be completed as best as possible **for bugs only** -->
+### Steps to Reproduce (for bugs only)
+<!-- If describing a bug, please include the **full** configuration of the plugin -->
+<!-- If describing a bug, is there a (public) project where this issue can be reproduced? -->
+<!-- If describing a bug, please include any stack-traces or any error messages -->
+
+### Environment (for bugs only)
+<!-- If describing a bug, please provide the plugin version is being used -->
+<!-- If describing a bug, please provide the Java-Version is being used (please include details about oracle-jdk VS open-jdk) -->
+<!-- If describing a bug, please provide the Maven-Version is being used (output of ``mvn --version``) -->
+<!-- If describing a bug, please let us know on what Operating System you experience the bug (on Linux run ``lsb_release -a``) -->
+<!-- If describing a bug, please let us know in what context maven is being executed (e.g. inside Windows Terminal, Powershell, Git Bash, /bin/bash, ...) -->
+<!-- If describing a bug, please let us know how maven is being executed (e.g. ``mvn clean deploy`` VS ``mvn deploy:deploy``) -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
     env: CUSTOM_MVN_VERION="3.3.9"
   - jdk: oraclejdk9
     env: CUSTOM_MVN_VERION="3.5.0"
+  - jdk: oraclejdk9
+    env: CUSTOM_MVN_VERION="3.5.2"
   - stage: checkstyle
     jdk: oraclejdk9
     script: mvn clean verify -Pcheckstyle -Dcheckstyle.version=8.2 -Dmaven.test.skip=true -B

--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                         -->
                         <forceLongFormat>false</forceLongFormat>
                     </gitDescribe>
+
                     <!-- @since 2.2.2 -->
                     <!-- 
                         Since version **2.2.2** the maven-git-commit-id-plugin comes equipped with an additional validation utility which can be used to verify if your project properties are set as you would like to have them set.
@@ -495,6 +496,7 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                         </validationProperty>
                         <!-- the next validationProperty you would like to validate -->
                     </validationProperties>
+
                     <!-- @since 2.2.2 -->
                     <!--
                         true by default, controls whether the validation will fail if *at least one* of the validationProperties does not match with it's expected values. 
@@ -502,6 +504,21 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                         *Note*: This configuration will only be taken into account when the additional goal `validateRevision` is configured inside an execution and at least one validationProperty is defined.
                     -->
                     <validationShouldFailIfNoMatch>true</validationShouldFailIfNoMatch>
+
+                    <!-- @since 2.2.4 -->
+                    <!--
+                        Allow to tell the plugin what commit should be used as reference to generate the properties from.
+                        By default this property is simply set to `HEAD` which should reference to the latest commit in your repository.
+
+                        In general this property can be set to something generic like `HEAD^1` or point to a branch or tag-name.
+                        To support any kind or use-case this configuration can also be set to an entire commit-hash or it's abbreviated version.
+
+                        A use-case for this feature can be found in https://github.com/ktoso/maven-git-commit-id-plugin/issues/338.
+
+                        Please note that for security purposes not all references might be allowed as configuration.
+                        If you have a specific use-case that is currently not white listed feel free to file an issue.
+                    -->
+                    <evaluateOnCommit>HEAD</evaluateOnCommit>
                 </configuration>
 
             </plugin>
@@ -882,6 +899,7 @@ Optional parameters:
 
 *Note*: Depending on your plugin configuration you obviously can choose the 'prefix' of your properties by setting it accordingly in the plugin's configuration. As a result this is therefore only an illustration what the switch means when the 'prefix' is set to it's default value.
 *Note*: If you set the value to something that's not equal to 'flat' or 'full' (ignoring the case) the plugin will output a warning and will fallback to the default 'flat' mode.
+* **evaluateOnCommit** - `(default: HEAD)` *(available since v2.2.4)* Allow to tell the plugin what commit should be used as reference to generate the properties from. By default this property is simply set to `HEAD` which should reference to the latest commit in your repository. In general this property can be set to something generic like `HEAD^1` or point to a branch or tag-name. To support any kind or use-case this configuration can also be set to an entire commit-hash or it's abbreviated version. Please note that for security purposes not all references might be allowed as configuration. If you have a specific use-case that is currently not white listed feel free to file an issue.
 
 **gitDescribe**:
 Worth pointing out is, that git-commit-id tries to be 1-to-1 compatible with git's plain output, even though the describe functionality has been reimplemented manually using JGit (you don't have to have a git executable to use the plugin). So if you're familiar with [git-describe](https://github.com/ktoso/maven-git-commit-id-plugin#git-describe---short-intro-to-an-awesome-command), you probably can skip this section, as it just explains the same options that git provides.

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.16.0</version>
+      <scope>test</scope>
+    </dependency>
+
     <!--to avoid complaints during tests-->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/pl/project13/jgit/JGitCommon.java
+++ b/src/main/java/pl/project13/jgit/JGitCommon.java
@@ -25,7 +25,6 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
-import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
@@ -84,16 +83,16 @@ public class JGitCommon {
     return tags;
   }
 
-  public String getClosestTagName(@NotNull Repository repo, GitDescribeConfig gitDescribe) {
+  public String getClosestTagName(@NotNull String evaluateOnCommit, @NotNull Repository repo, GitDescribeConfig gitDescribe) {
     // TODO: Why does some tests fail when it gets headCommit from JGitprovider?
-    RevCommit headCommit = findHeadObjectId(repo);
+    RevCommit headCommit = findEvalCommitObjectId(evaluateOnCommit, repo);
     Pair<RevCommit, String> pair = getClosestRevCommit(repo, headCommit, gitDescribe);
     return pair.second;
   }
 
-  public String getClosestTagCommitCount(@NotNull Repository repo, GitDescribeConfig gitDescribe) {
+  public String getClosestTagCommitCount(@NotNull String evaluateOnCommit, @NotNull Repository repo, GitDescribeConfig gitDescribe) {
     // TODO: Why does some tests fail when it gets headCommit from JGitprovider?
-    RevCommit headCommit = findHeadObjectId(repo);
+    RevCommit headCommit = findEvalCommitObjectId(evaluateOnCommit, repo);
     Pair<RevCommit, String> pair = getClosestRevCommit(repo, headCommit, gitDescribe);
     RevCommit revCommit = pair.first;
     int distance = distanceBetween(repo, headCommit, revCommit);
@@ -135,19 +134,19 @@ public class JGitCommon {
     return commitIdsToTagNames;
   }
 
-  protected RevCommit findHeadObjectId(@NotNull Repository repo) throws RuntimeException {
+  protected RevCommit findEvalCommitObjectId(@NotNull String evaluateOnCommit, @NotNull Repository repo) throws RuntimeException {
     try {
-      ObjectId headId = repo.resolve(Constants.HEAD);
+      ObjectId evalCommitId = repo.resolve(evaluateOnCommit);
 
       try (RevWalk walk = new RevWalk(repo)) {
-        RevCommit headCommit = walk.lookupCommit(headId);
+        RevCommit evalCommit = walk.parseCommit(evalCommitId);
         walk.dispose();
 
-        log.info("HEAD is [{}]", headCommit.getName());
-        return headCommit;
+        log.info("evalCommit is [{}]", evalCommit.getName());
+        return evalCommit;
       }
     } catch (IOException ex) {
-      throw new RuntimeException("Unable to obtain HEAD commit!", ex);
+      throw new RuntimeException("Unable to obtain " + evaluateOnCommit + " commit!", ex);
     }
   }
 

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -49,6 +49,8 @@ public abstract class GitDataProvider implements GitProvider {
 
   protected CommitIdGenerationMode commitIdGenerationMode;
 
+  protected String evaluateOnCommit;
+
   public GitDataProvider(@NotNull LoggerBridge log) {
     this.log = log;
   }
@@ -83,7 +85,8 @@ public abstract class GitDataProvider implements GitProvider {
     return this;
   }
 
-  public void loadGitData(@NotNull Properties properties) throws GitCommitIdExecutionException {
+  public void loadGitData(@NotNull String evaluateOnCommit, @NotNull Properties properties) throws GitCommitIdExecutionException {
+    this.evaluateOnCommit = evaluateOnCommit;
     init();
     // git.user.name
     put(properties, GitCommitPropertyConstant.BUILD_AUTHOR_NAME, getBuildAuthorName());

--- a/src/test/java/pl/project13/jgit/DescribeCommandAbbrevIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandAbbrevIntegrationTest.java
@@ -69,7 +69,7 @@ public class DescribeCommandAbbrevIntegrationTest extends GitIntegrationTest {
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .abbrev(2) // 2 is enough to be unique in this small repo
               .call();
 
@@ -93,7 +93,7 @@ public class DescribeCommandAbbrevIntegrationTest extends GitIntegrationTest {
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .abbrev(2) // way too small to be unique in git-commit-id's repo!
               .call();
 

--- a/src/test/java/pl/project13/jgit/DescribeCommandIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandIntegrationTest.java
@@ -59,7 +59,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .call();
 
       // then
@@ -81,7 +81,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
 
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
-      DescribeCommand command = spy(DescribeCommand.on(repo, new StdOutLoggerBridge(true)));
+      DescribeCommand command = spy(DescribeCommand.on(evaluateOnCommit, repo, new StdOutLoggerBridge(true)));
       doReturn(false).when(command).findDirtyState(any(Repository.class));
 
       DescribeResult res = command.call();
@@ -105,7 +105,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
 
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
-      DescribeCommand command = spy(DescribeCommand.on(repo, new StdOutLoggerBridge(true)));
+      DescribeCommand command = spy(DescribeCommand.on(evaluateOnCommit, repo, new StdOutLoggerBridge(true)));
       doReturn(false).when(command).findDirtyState(any(Repository.class));
 
       DescribeResult res = command.call();
@@ -130,7 +130,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
     int abbrevLength = 10;
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
-      DescribeCommand command = spy(DescribeCommand.on(repo, new StdOutLoggerBridge(true)));
+      DescribeCommand command = spy(DescribeCommand.on(evaluateOnCommit, repo, new StdOutLoggerBridge(true)));
       doReturn(false).when(command).findDirtyState(any(Repository.class));
 
       command
@@ -156,7 +156,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
 
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
-      DescribeCommand command = DescribeCommand.on(repo, new StdOutLoggerBridge(true));
+      DescribeCommand command = DescribeCommand.on(evaluateOnCommit, repo, new StdOutLoggerBridge(true));
       command.dirty(DIRTY_SUFFIX);
       DescribeResult res = command.call();
 
@@ -181,7 +181,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
       DescribeCommand command = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .dirty(customDirtySuffix);
       DescribeResult res = command.call();
 
@@ -207,7 +207,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
       }
 
       // when
-      DescribeCommand command = DescribeCommand.on(repo, new StdOutLoggerBridge(true));
+      DescribeCommand command = DescribeCommand.on(evaluateOnCommit, repo, new StdOutLoggerBridge(true));
       DescribeResult res = command.call();
 
       // then
@@ -231,7 +231,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
 
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .tags()
               .call();
 
@@ -256,7 +256,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
 
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .tags()
               .call();
 
@@ -283,7 +283,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
 
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .tags()
               .dirty(customDirtySuffix)
               .call();
@@ -307,7 +307,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .tags()
               .call();
 
@@ -328,7 +328,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
     try (final Git git = git(); final Repository repo = git.getRepository()) {
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .dirty(DIRTY_SUFFIX)
               .abbrev(0)
               .call();
@@ -356,7 +356,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
 
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .tags()
               .call();
 
@@ -416,7 +416,7 @@ public class DescribeCommandIntegrationTest extends GitIntegrationTest {
 
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .abbrev(zeroAbbrev)
               .call();
 

--- a/src/test/java/pl/project13/jgit/DescribeCommandOptionsTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandOptionsTest.java
@@ -26,7 +26,7 @@ import pl.project13.maven.git.log.StdOutLoggerBridge;
 import static org.mockito.Mockito.*;
 
 public class DescribeCommandOptionsTest {
-
+  private static final String evaluateOnCommit = "HEAD";
 
   @Test(expected = IllegalArgumentException.class)
   public void abbrev_shouldVerifyLengthContract_failOn41() throws Exception {
@@ -34,7 +34,7 @@ public class DescribeCommandOptionsTest {
     final Repository repo = mock(Repository.class);
     final int length = 41;
 
-    DescribeCommand.on(repo, new StdOutLoggerBridge(true)).abbrev(length);
+    DescribeCommand.on(evaluateOnCommit, repo, new StdOutLoggerBridge(true)).abbrev(length);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -43,7 +43,7 @@ public class DescribeCommandOptionsTest {
     final Repository repo = mock(Repository.class);
     final int length = -12;
 
-    DescribeCommand.on(repo, new StdOutLoggerBridge(true)).abbrev(length);
+    DescribeCommand.on(evaluateOnCommit, repo, new StdOutLoggerBridge(true)).abbrev(length);
   }
 
   @Test
@@ -56,7 +56,7 @@ public class DescribeCommandOptionsTest {
     GitDescribeConfig config = new GitDescribeConfig(true, devel, match, abbrev, true, true);
 
     Repository repo = mock(Repository.class);
-    DescribeCommand command = DescribeCommand.on(repo, new StdOutLoggerBridge(true));
+    DescribeCommand command = DescribeCommand.on(evaluateOnCommit, repo, new StdOutLoggerBridge(true));
     DescribeCommand spiedCommand = spy(command);
 
     // when

--- a/src/test/java/pl/project13/jgit/DescribeCommandTagsIntegrationTest.java
+++ b/src/test/java/pl/project13/jgit/DescribeCommandTagsIntegrationTest.java
@@ -63,7 +63,7 @@ public class DescribeCommandTagsIntegrationTest extends GitIntegrationTest {
 
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .call();
 
       // then
@@ -86,7 +86,7 @@ public class DescribeCommandTagsIntegrationTest extends GitIntegrationTest {
 
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .tags()
               .call();
 
@@ -110,7 +110,7 @@ public class DescribeCommandTagsIntegrationTest extends GitIntegrationTest {
 
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .tags()
               .match("annotated*")
               .call();
@@ -146,7 +146,7 @@ public class DescribeCommandTagsIntegrationTest extends GitIntegrationTest {
 
       // when
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .tags()
               .call();
 
@@ -179,7 +179,7 @@ public class DescribeCommandTagsIntegrationTest extends GitIntegrationTest {
         wrap.tag().setName(latestTag).call();
 
         DescribeResult res = DescribeCommand
-                .on(repo, new StdOutLoggerBridge(true))
+                .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
                 .tags()
                 .call();
 
@@ -211,7 +211,7 @@ public class DescribeCommandTagsIntegrationTest extends GitIntegrationTest {
       }
 
       DescribeResult res = DescribeCommand
-              .on(repo, new StdOutLoggerBridge(true))
+              .on(evaluateOnCommit, repo, new StdOutLoggerBridge(true))
               .tags()
               .call();
 

--- a/src/test/java/pl/project13/maven/git/AvailableGitTestRepo.java
+++ b/src/test/java/pl/project13/maven/git/AvailableGitTestRepo.java
@@ -57,6 +57,14 @@ public enum AvailableGitTestRepo {
    * </pre>
    */
   WITH_LIGHTWEIGHT_TAG_BEFORE_ANNOTATED_TAG("src/test/resources/_git_lightweight_tag_before_annotated_tag"),
+  /**
+   * <pre>
+   * * 9cb810e - Change in tag - Fri, 29 Nov 2013 10:39:31 +0100 (tag: test_tag, branch: test)
+   * | * 2343428 - Moved master - Fri, 29 Nov 2013 10:38:34 +0100 (HEAD, branch: master)
+   * |/
+   * * e3d159d - Added readme - Fri, 29 Nov 2013 10:38:02 +0100
+   * </pre>
+   */
   WITH_TAG_ON_DIFFERENT_BRANCH("src/test/resources/_git_with_tag_on_different_branch"),
   WITH_ONE_COMMIT_WITH_SPECIAL_CHARACTERS("src/test/resources/_git_one_commit_with_umlaut"),
   /**

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -981,6 +981,141 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.closest.tag.commit.count", "1");
   }
 
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void verifyEvalOnDifferentCommitWithParentOfHead(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox
+                .withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_TAG_ON_DIFFERENT_BRANCH)
+                .create();
+
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+
+    GitDescribeConfig gitDescribe = createGitDescribeConfig(true, 9);
+    gitDescribe.setDirty(null);
+
+    mojo.setGitDescribe(gitDescribe);
+    mojo.setUseNativeGit(useNativeGit);
+    mojo.setEvaluateOnCommit("HEAD^1");
+
+    // when
+    mojo.execute();
+
+    // then
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.commit.id.abbrev", "e3d159d");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.commit.id.describe", "e3d159dd7");
+
+    // TODO: FIXME https://github.com/ktoso/maven-git-commit-id-plugin/issues/339
+    // assertPropertyPresentAndEqual(targetProject.getProperties(), "git.tags", "test_tag");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.dirty", "true");
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void verifyEvalOnDifferentCommitWithBranchName(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox
+                .withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_TAG_ON_DIFFERENT_BRANCH)
+                .create();
+
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+
+    GitDescribeConfig gitDescribe = createGitDescribeConfig(true, 9);
+    gitDescribe.setDirty(null);
+
+    mojo.setGitDescribe(gitDescribe);
+    mojo.setUseNativeGit(useNativeGit);
+    mojo.setEvaluateOnCommit("test");
+
+    // when
+    mojo.execute();
+
+    // then
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.commit.id.abbrev", "9cb810e");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.commit.id.describe", "test_tag-0-g9cb810e57");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.tags", "test_tag");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.dirty", "true");
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void verifyEvalOnDifferentCommitWithTagName(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox
+                .withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_TAG_ON_DIFFERENT_BRANCH)
+                .create();
+
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+
+    GitDescribeConfig gitDescribe = createGitDescribeConfig(true, 9);
+    gitDescribe.setDirty(null);
+
+    mojo.setGitDescribe(gitDescribe);
+    mojo.setUseNativeGit(useNativeGit);
+    mojo.setEvaluateOnCommit("test_tag");
+
+    // when
+    mojo.execute();
+
+    // then
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.commit.id.abbrev", "9cb810e");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.commit.id.describe", "test_tag-0-g9cb810e57");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.tags", "test_tag");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.dirty", "true");
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void verifyEvalOnDifferentCommitWithCommitHash(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox
+                .withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_TAG_ON_DIFFERENT_BRANCH)
+                .create();
+
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+
+    GitDescribeConfig gitDescribe = createGitDescribeConfig(true, 9);
+    gitDescribe.setDirty(null);
+
+    mojo.setGitDescribe(gitDescribe);
+    mojo.setUseNativeGit(useNativeGit);
+    mojo.setEvaluateOnCommit("9cb810e");
+
+    // when
+    mojo.execute();
+
+    // then
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.commit.id.abbrev", "9cb810e");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.commit.id.describe", "test_tag-0-g9cb810e57");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.tags", "test_tag");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.dirty", "true");
+  }
+
+  // TODO: Test that fails when trying to pass invalid data to evaluateOnCommit
+
   private GitDescribeConfig createGitDescribeConfig(boolean forceLongFormat, int abbrev) {
     GitDescribeConfig gitDescribeConfig = new GitDescribeConfig();
     gitDescribeConfig.setTags(true);

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -19,7 +19,10 @@ package pl.project13.maven.git;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import com.google.common.io.Files;
+
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -27,7 +30,10 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ResetCommand;
+import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -42,6 +48,9 @@ import static org.fest.assertions.MapAssert.entry;
 @RunWith(JUnitParamsRunner.class)
 public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
 
+  @Rule
+  public final EnvironmentVariables environmentVariablesMock = new EnvironmentVariables();
+
   static final boolean UseJGit = false;
   static final boolean UseNativeGit = true;
 
@@ -55,9 +64,290 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
 
   @Test
   @Parameters(method = "useNativeGit")
+  public void shouldIncludeExpectedProperties(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+    mojo.setUseNativeGit(useNativeGit);
+
+    // when
+    mojo.execute();
+
+    // then
+    Properties properties = targetProject.getProperties();
+
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.branch"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.dirty"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.full"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.abbrev"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.name"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.email"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.name"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.email"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.full"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.short"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.time"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.remote.origin.url"));
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldExcludeAsConfiguredProperties(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+    mojo.setUseNativeGit(useNativeGit);
+    mojo.setExcludeProperties(ImmutableList.of("git.remote.origin.url", ".*.user.*"));
+
+    // when
+    mojo.execute();
+
+    // then
+    Properties properties = targetProject.getProperties();
+
+    // explicitly excluded
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.remote.origin.url"));
+
+    // glob excluded
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.build.user.name"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.build.user.email"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.user.name"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.user.email"));
+
+    // these stay
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.branch"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.full"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.abbrev"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.full"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.short"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.time"));
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldIncludeOnlyAsConfiguredProperties(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+    mojo.setUseNativeGit(useNativeGit);
+    mojo.setIncludeOnlyProperties(ImmutableList.of("git.remote.origin.url", ".*.user.*", "^git.commit.id.full$"));
+
+    // when
+    mojo.execute();
+
+    // then
+    Properties properties = targetProject.getProperties();
+
+    // explicitly included
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.remote.origin.url"));
+
+    // glob included
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.name"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.email"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.full"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.name"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.email"));
+
+    // these excluded
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.branch"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.id.abbrev"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.message.full"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.message.short"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.time"));
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldExcludeAndIncludeAsConfiguredProperties(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+    mojo.setUseNativeGit(useNativeGit);
+    mojo.setIncludeOnlyProperties(ImmutableList.of("git.remote.origin.url", ".*.user.*"));
+    mojo.setExcludeProperties(ImmutableList.of("git.build.user.email"));
+
+    // when
+    mojo.execute();
+
+    // then
+    Properties properties = targetProject.getProperties();
+
+    // explicitly included
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.remote.origin.url"));
+
+    // explicitly excluded -> overrules include only properties
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.build.user.email"));
+
+    // glob included
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.name"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.name"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.email"));
+
+    // these excluded
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.branch"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.id.full"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.id.abbrev"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.message.full"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.message.short"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.time"));
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldHaveNoPrefixWhenConfiguredPrefixIsEmptyStringAsConfiguredProperties(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+    mojo.setUseNativeGit(useNativeGit);
+    mojo.setPrefix("");
+
+    // when
+    mojo.execute();
+
+    // then
+    Properties properties = targetProject.getProperties();
+
+    // explicitly excluded
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.remote.origin.url"));
+    assertThat(properties).satisfies(new DoesNotContainKeyCondition(".remote.origin.url"));
+    assertThat(properties).satisfies(new ContainsKeyCondition("remote.origin.url"));
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldSkipDescribeWhenConfiguredToDoSo(boolean useNativeGit) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+
+    GitDescribeConfig config = new GitDescribeConfig();
+    config.setSkip(true);
+
+    // when
+    mojo.setGitDescribe(config);
+    mojo.execute();
+
+    // then
+    assertThat(targetProject.getProperties()).satisfies(new DoesNotContainKeyCondition("git.commit.id.describe"));
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
+  public void shouldUseJenkinsBranchInfoWhenAvailable(boolean useNativeGit) throws Exception {
+    // given
+    Map<String, String> env = Maps.newHashMap();
+
+    String detachedHeadSha1 = "b6a73ed747dd8dc98642d731ddbf09824efb9d48";
+    String ciUrl = "http://myciserver.com";
+
+    // when
+    // in a detached head state, getBranch() will return the SHA1...standard behavior
+    shouldUseJenkinsBranchInfoWhenAvailableHelperAndAssertBranch(useNativeGit, env, detachedHeadSha1);
+
+    // again, SHA1 will be returned if we're in jenkins, but GIT_BRANCH is not set
+    env.put("JENKINS_URL", ciUrl);
+    shouldUseJenkinsBranchInfoWhenAvailableHelperAndAssertBranch(useNativeGit, env, detachedHeadSha1);
+
+    // now set GIT_BRANCH too and see that the branch name from env var is returned
+    env.clear();
+    env.put("JENKINS_URL", ciUrl);
+    env.put("GIT_BRANCH", "mybranch");
+    shouldUseJenkinsBranchInfoWhenAvailableHelperAndAssertBranch(useNativeGit, env, "mybranch");
+
+    // same, but for hudson
+    env.clear();
+    env.put("HUDSON_URL", ciUrl);
+    env.put("GIT_BRANCH", "mybranch");
+    shouldUseJenkinsBranchInfoWhenAvailableHelperAndAssertBranch(useNativeGit, env, "mybranch");
+
+    // now set GIT_LOCAL_BRANCH too and see that the branch name from env var is returned
+    env.clear();
+    env.put("JENKINS_URL", ciUrl);
+    env.put("GIT_BRANCH", "mybranch");
+    env.put("GIT_LOCAL_BRANCH", "mylocalbranch");
+    shouldUseJenkinsBranchInfoWhenAvailableHelperAndAssertBranch(useNativeGit, env, "mylocalbranch");
+
+    // same, but for hudson
+    env.clear();
+    env.put("HUDSON_URL", ciUrl);
+    env.put("GIT_BRANCH", "mybranch");
+    env.put("GIT_LOCAL_BRANCH", "mylocalbranch");
+    shouldUseJenkinsBranchInfoWhenAvailableHelperAndAssertBranch(useNativeGit, env, "mylocalbranch");
+
+    // GIT_BRANCH but no HUDSON_URL or JENKINS_URL
+    env.clear();
+    env.put("GIT_BRANCH", "mybranch");
+    env.put("GIT_LOCAL_BRANCH", "mylocalbranch");
+    shouldUseJenkinsBranchInfoWhenAvailableHelperAndAssertBranch(useNativeGit, env, detachedHeadSha1);
+  }
+
+  private void shouldUseJenkinsBranchInfoWhenAvailableHelperAndAssertBranch(boolean useNativeGit, Map<String, String> env, String expectedBranchName) throws Exception {
+    // given
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_COMMIT_THAT_HAS_TWO_TAGS)
+                .create();
+    MavenProject targetProject = mavenSandbox.getParentProject();
+    setProjectToExecuteMojoIn(targetProject);
+
+    // remove all keys from System.getenv()
+    List<String> keySet = new ArrayList<>(System.getenv().keySet());
+    for (String key: keySet) {
+      environmentVariablesMock.set(key, null);
+    }
+    // set System.getenv() to be equal to given parameter env
+    for (Map.Entry<String, String> entry: env.entrySet()) {
+      environmentVariablesMock.set(entry.getKey(), entry.getValue());
+    }
+
+    // verify that System.getenv() is actually equal
+    Assert.assertEquals(env, System.getenv());
+
+    // reset repo and force detached HEAD
+    try (final Git git = git("my-jar-project")) {
+      git.reset().setMode(ResetCommand.ResetType.HARD).setRef("b6a73ed").call();
+      git.checkout().setName("b6a73ed").setForce(true).call();
+    }
+
+    // when
+    mojo.execute();
+
+    // then
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.branch", expectedBranchName);
+  }
+
+  @Test
+  @Parameters(method = "useNativeGit")
   public void shouldResolvePropertiesOnDefaultSettingsForNonPomProject(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox.withParentProject("my-jar-project", "jar").withNoChildProject().withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT).create();
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
     mojo.setUseNativeGit(useNativeGit);
@@ -73,7 +363,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldNotRunWhenSkipIsSet(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox.withParentProject("my-skip-project", "jar").withNoChildProject().withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT).create();
+    mavenSandbox.withParentProject("my-skip-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
     mojo.setSkip(true);
@@ -90,7 +383,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldNotRunWhenPackagingPomAndDefaultSettingsApply(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox.withParentProject("my-pom-project", "pom").withNoChildProject().withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT).create();
+    mavenSandbox.withParentProject("my-pom-project", "pom")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
     mojo.setUseNativeGit(useNativeGit);
@@ -106,7 +402,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldRunWhenPackagingPomAndSkipPomsFalse(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox.withParentProject("my-pom-project", "pom").withNoChildProject().withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT).create();
+    mavenSandbox.withParentProject("my-pom-project", "pom")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
     mojo.setSkipPoms(false);
@@ -123,7 +422,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldUseParentProjectRepoWhenInvokedFromChild(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox.withParentProject("my-pom-project", "pom").withChildProject("my-jar-module", "jar").withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT).create();
+    mavenSandbox.withParentProject("my-pom-project", "pom")
+                .withChildProject("my-jar-module", "jar")
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
     MavenProject targetProject = mavenSandbox.getChildProject();
     setProjectToExecuteMojoIn(targetProject);
     mojo.setSkipPoms(false);
@@ -140,7 +442,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldUseChildProjectRepoIfInvokedFromChild(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox.withParentProject("my-pom-project", "pom").withChildProject("my-jar-module", "jar").withGitRepoInChild(AvailableGitTestRepo.WITH_ONE_COMMIT).create();
+    mavenSandbox.withParentProject("my-pom-project", "pom")
+                .withChildProject("my-jar-module", "jar")
+                .withGitRepoInChild(AvailableGitTestRepo.WITH_ONE_COMMIT)
+                .create();
     MavenProject targetProject = mavenSandbox.getChildProject();
     setProjectToExecuteMojoIn(targetProject);
     mojo.setSkipPoms(false);
@@ -161,7 +466,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withNoGitRepoAvailable()
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
     setProjectToExecuteMojoIn(targetProject);
     mojo.setSkipPoms(false);
@@ -178,7 +482,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withGitRepoInChild(AvailableGitTestRepo.WITH_ONE_COMMIT_WITH_SPECIAL_CHARACTERS)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
 
     String targetFilePath = "target/classes/custom-git.properties";
@@ -208,7 +511,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withGitRepoInChild(AvailableGitTestRepo.WITH_ONE_COMMIT_WITH_SPECIAL_CHARACTERS)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
 
     String targetFilePath = "target/classes/custom-git.properties";
@@ -243,7 +545,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withNoChildProject()
                 .withNoGitRepoAvailable()
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
     mojo.setFailOnNoGitDirectory(false);
@@ -264,7 +565,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withNoChildProject()
                 .withGitRepoInParent(AvailableGitTestRepo.WITH_ONE_COMMIT)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
     mojo.setFailOnNoGitDirectory(false);
@@ -285,7 +585,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
 
     setProjectToExecuteMojoIn(targetProject);
@@ -310,7 +609,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
 
     setProjectToExecuteMojoIn(targetProject);
@@ -335,7 +633,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
 
     setProjectToExecuteMojoIn(targetProject);
@@ -358,7 +655,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
 
     setProjectToExecuteMojoIn(targetProject);
@@ -383,7 +679,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
 
     setProjectToExecuteMojoIn(targetProject);
@@ -405,7 +700,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
 
     setProjectToExecuteMojoIn(targetProject);
@@ -567,12 +861,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldExtractTagsOnGivenCommit(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-      .withParentProject("my-jar-project", "jar")
-      .withNoChildProject()
-      .withGitRepoInParent(AvailableGitTestRepo.WITH_COMMIT_THAT_HAS_TWO_TAGS)
-      .create();
-
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_COMMIT_THAT_HAS_TWO_TAGS)
+                .create();
 
     try (final Git git = git("my-jar-project")) {
       git.reset().setMode(ResetCommand.ResetType.HARD).setRef("d37a598").call();
@@ -647,7 +939,6 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
                 .withChildProject("my-jar-module", "jar")
                 .withGitRepoInChild(AvailableGitTestRepo.ON_A_TAG)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getChildProject();
 
     setProjectToExecuteMojoIn(targetProject);
@@ -698,11 +989,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldGenerateClosestTagInformationWhenCommitHasTwoTags(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-      .withParentProject("my-jar-project", "jar")
-      .withNoChildProject()
-      .withGitRepoInParent(AvailableGitTestRepo.WITH_COMMIT_THAT_HAS_TWO_TAGS)
-      .create();
+    mavenSandbox.withParentProject("my-jar-project", "jar")
+                .withNoChildProject()
+                .withGitRepoInParent(AvailableGitTestRepo.WITH_COMMIT_THAT_HAS_TWO_TAGS)
+                .create();
 
     try (final Git git = git("my-jar-project")) {
       git.reset().setMode(ResetCommand.ResetType.HARD).setRef("d37a598").call();
@@ -852,12 +1142,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldGenerateClosestTagInformationWithExcludeLightweightTagsForClosestTag(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-                .withParentProject("my-jar-project", "jar")
+    mavenSandbox.withParentProject("my-jar-project", "jar")
                 .withNoChildProject()
                 .withGitRepoInParent(AvailableGitTestRepo.WITH_LIGHTWEIGHT_TAG_BEFORE_ANNOTATED_TAG)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
 
@@ -885,12 +1173,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldGenerateClosestTagInformationWithIncludeLightweightTagsForClosestTag(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-                .withParentProject("my-jar-project", "jar")
+    mavenSandbox.withParentProject("my-jar-project", "jar")
                 .withNoChildProject()
                 .withGitRepoInParent(AvailableGitTestRepo.WITH_LIGHTWEIGHT_TAG_BEFORE_ANNOTATED_TAG)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
 
@@ -918,12 +1204,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldGenerateClosestTagInformationWithIncludeLightweightTagsForClosestTagAndPreferAnnotatedTags(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-                .withParentProject("my-jar-project", "jar")
+    mavenSandbox.withParentProject("my-jar-project", "jar")
                 .withNoChildProject()
                 .withGitRepoInParent(AvailableGitTestRepo.WITH_COMMIT_THAT_HAS_TWO_TAGS)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
 
@@ -951,12 +1235,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void shouldGenerateClosestTagInformationWithIncludeLightweightTagsForClosestTagAndFilter(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-                .withParentProject("my-jar-project", "jar")
+    mavenSandbox.withParentProject("my-jar-project", "jar")
                 .withNoChildProject()
                 .withGitRepoInParent(AvailableGitTestRepo.WITH_COMMIT_THAT_HAS_TWO_TAGS)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
 
@@ -985,12 +1267,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void verifyEvalOnDifferentCommitWithParentOfHead(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-                .withParentProject("my-jar-project", "jar")
+    mavenSandbox.withParentProject("my-jar-project", "jar")
                 .withNoChildProject()
                 .withGitRepoInParent(AvailableGitTestRepo.WITH_TAG_ON_DIFFERENT_BRANCH)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
 
@@ -1019,12 +1299,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void verifyEvalOnDifferentCommitWithBranchName(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-                .withParentProject("my-jar-project", "jar")
+    mavenSandbox.withParentProject("my-jar-project", "jar")
                 .withNoChildProject()
                 .withGitRepoInParent(AvailableGitTestRepo.WITH_TAG_ON_DIFFERENT_BRANCH)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
 
@@ -1052,12 +1330,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void verifyEvalOnDifferentCommitWithTagName(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-                .withParentProject("my-jar-project", "jar")
+    mavenSandbox.withParentProject("my-jar-project", "jar")
                 .withNoChildProject()
                 .withGitRepoInParent(AvailableGitTestRepo.WITH_TAG_ON_DIFFERENT_BRANCH)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
 
@@ -1085,12 +1361,10 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
   @Parameters(method = "useNativeGit")
   public void verifyEvalOnDifferentCommitWithCommitHash(boolean useNativeGit) throws Exception {
     // given
-    mavenSandbox
-                .withParentProject("my-jar-project", "jar")
+    mavenSandbox.withParentProject("my-jar-project", "jar")
                 .withNoChildProject()
                 .withGitRepoInParent(AvailableGitTestRepo.WITH_TAG_ON_DIFFERENT_BRANCH)
                 .create();
-
     MavenProject targetProject = mavenSandbox.getParentProject();
     setProjectToExecuteMojoIn(targetProject);
 

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -1351,8 +1351,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
 
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.commit.id.describe", "e3d159dd7");
 
-    // TODO: FIXME https://github.com/ktoso/maven-git-commit-id-plugin/issues/339
-    // assertPropertyPresentAndEqual(targetProject.getProperties(), "git.tags", "test_tag");
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.tags", "test_tag");
 
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.dirty", "true");
   }

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoTest.java
@@ -17,261 +17,21 @@
 
 package pl.project13.maven.git;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.project.MavenProject;
-import org.eclipse.jgit.lib.Repository;
-import org.junit.Before;
 import org.junit.Test;
-import pl.project13.maven.git.log.StdOutLoggerBridge;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
+
 import java.util.Properties;
 import java.util.regex.Pattern;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
 
-/**
- * I'm not a big fan of this test - let's move to integration test from now on.
- *
- */
-// todo remove this test in favor of complete integration tests
 public class GitCommitIdMojoTest {
 
-  GitCommitIdMojo mojo;
-  JGitProvider jGitProvider;
-
-  @Before
-  public void setUp() throws Exception {
-    File dotGitDirectory = AvailableGitTestRepo.GIT_COMMIT_ID.getDir();
-    GitDescribeConfig gitDescribeConfig = new GitDescribeConfig();
-    gitDescribeConfig.setSkip(false);
-
-    String prefix = "git";
-    int abbrevLength = 7;
-    String dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ";
-
-    mojo = new GitCommitIdMojo();
-    mojo.setDotGitDirectory(dotGitDirectory);
-    mojo.setPrefix(prefix);
-    mojo.setAbbrevLength(abbrevLength);
-    mojo.setDateFormat(dateFormat);
-    mojo.setVerbose(true);
-    mojo.setUseNativeGit(false);
-    mojo.setGitDescribe(gitDescribeConfig);
-    mojo.setCommitIdGenerationMode("full");
-    mojo.setEvaluateOnCommit("HEAD");
-
-
-    mojo.project = mock(MavenProject.class, RETURNS_MOCKS);
-    Properties props = new Properties();
-    when(mojo.project.getProperties()).thenReturn(props);
-    when(mojo.project.getPackaging()).thenReturn("jar");
-    when(mojo.project.getVersion()).thenReturn("3.3-SNAPSHOT");
-
-    jGitProvider = JGitProvider.on(mojo.lookupGitDirectory(), new StdOutLoggerBridge(true));
-  }
-
-  @Test
-  public void shouldIncludeExpectedProperties() throws Exception {
-    mojo.execute();
-
-    Properties properties = mojo.getProperties();
-
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.branch"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.dirty"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.full"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.abbrev"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.name"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.email"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.name"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.email"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.full"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.short"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.time"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.remote.origin.url"));
-  }
-
-  @Test
-  public void shouldExcludeAsConfiguredProperties() throws Exception {
-    // given
-    mojo.setExcludeProperties(ImmutableList.of("git.remote.origin.url", ".*.user.*"));
-
-    // when
-    mojo.execute();
-
-    // then
-    Properties properties = mojo.getProperties();
-
-    // explicitly excluded
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.remote.origin.url"));
-
-    // glob excluded
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.build.user.name"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.build.user.email"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.user.name"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.user.email"));
-
-    // these stay
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.branch"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.full"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.abbrev"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.full"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.message.short"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.time"));
-  }
-
-  @Test
-  public void shouldIncludeOnlyAsConfiguredProperties() throws Exception {
-    // given
-    mojo.setIncludeOnlyProperties(ImmutableList.of("git.remote.origin.url", ".*.user.*", "^git.commit.id.full$"));
-
-    // when
-    mojo.execute();
-
-    // then
-    Properties properties = mojo.getProperties();
-
-    // explicitly included
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.remote.origin.url"));
-
-    // glob included
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.name"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.email"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.id.full"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.name"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.email"));
-
-    // these excluded
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.branch"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.id.abbrev"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.message.full"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.message.short"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.time"));
-  }
-
-  @Test
-  public void shouldExcludeAndIncludeAsConfiguredProperties() throws Exception {
-    // given
-    mojo.setIncludeOnlyProperties(ImmutableList.of("git.remote.origin.url", ".*.user.*"));
-    mojo.setExcludeProperties(ImmutableList.of("git.build.user.email"));
-
-    // when
-    mojo.execute();
-
-    // then
-    Properties properties = mojo.getProperties();
-
-    // explicitly included
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.remote.origin.url"));
-
-    // explicitly excluded -> overrules include only properties
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.build.user.email"));
-
-    // glob included
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.build.user.name"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.name"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("git.commit.user.email"));
-
-    // these excluded
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.branch"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.id.full"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.id.abbrev"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.message.full"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.message.short"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.commit.time"));
-  }
-
-  @Test
-  public void shouldHaveNoPrefixWhenConfiguredPrefixIsEmptyStringAsConfiguredProperties() throws Exception {
-    // given
-    mojo.setPrefix("");
-
-    // when
-    mojo.execute();
-
-    // then
-    Properties properties = mojo.getProperties();
-
-    // explicitly excluded
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition("git.remote.origin.url"));
-    assertThat(properties).satisfies(new DoesNotContainKeyCondition(".remote.origin.url"));
-    assertThat(properties).satisfies(new ContainsKeyCondition("remote.origin.url"));
-  }
-
-  @Test
-  public void shouldSkipDescribeWhenConfiguredToDoSo() throws Exception {
-    // given
-    GitDescribeConfig config = new GitDescribeConfig();
-    config.setSkip(true);
-
-    // when
-    mojo.setGitDescribe(config);
-    mojo.execute();
-
-    // then
-    assertThat(mojo.getProperties()).satisfies(new DoesNotContainKeyCondition("git.commit.id.describe"));
-  }
-
-  @Test
-  public void shouldUseJenkinsBranchInfoWhenAvailable() throws GitCommitIdExecutionException, IOException {
-    // given
-    Repository git = mock(Repository.class);
-    Map<String, String> env = Maps.newHashMap();
-
-    String detachedHeadSha1 = "16bb801934e652f5e291a003db05e364d83fba25";
-    String ciUrl = "http://myciserver.com";
-
-    when(git.getBranch()).thenReturn(detachedHeadSha1);
-    jGitProvider.setRepository(git);
-    // when
-    // in a detached head state, getBranch() will return the SHA1...standard behavior
-    assertThat(detachedHeadSha1).isEqualTo(jGitProvider.determineBranchName(env));
-
-    // again, SHA1 will be returned if we're in jenkins, but GIT_BRANCH is not set
-    env.put("JENKINS_URL", "http://myjenkinsserver.com");
-    assertThat(detachedHeadSha1).isEqualTo(jGitProvider.determineBranchName(env));
-
-    // now set GIT_BRANCH too and see that the branch name from env var is returned
-    env.clear();
-    env.put("JENKINS_URL", ciUrl);
-    env.put("GIT_BRANCH", "mybranch");
-    assertThat("mybranch").isEqualTo(jGitProvider.determineBranchName(env));
-  
-    // same, but for hudson
-    env.clear();
-    env.put("GIT_BRANCH", "mybranch");
-    env.put("HUDSON_URL", ciUrl);
-    assertThat("mybranch").isEqualTo(jGitProvider.determineBranchName(env));
-
-    // now set GIT_LOCAL_BRANCH too and see that the branch name from env var is returned
-    env.clear();
-    env.put("JENKINS_URL", ciUrl);
-    env.put("GIT_BRANCH", "mybranch");
-    env.put("GIT_LOCAL_BRANCH", "mylocalbranch");
-    assertThat("mylocalbranch").isEqualTo(jGitProvider.determineBranchName(env));
-
-    // same, but for hudson
-    env.clear();
-    env.put("GIT_BRANCH", "mybranch");
-    env.put("GIT_LOCAL_BRANCH", "mylocalbranch");
-    env.put("HUDSON_URL", ciUrl);
-    assertThat("mylocalbranch").isEqualTo(jGitProvider.determineBranchName(env));
-
-    // GIT_BRANCH but no HUDSON_URL or JENKINS_URL
-    env.clear();
-    env.put("GIT_BRANCH", "mybranch");
-    env.put("GIT_BRANCH", "mylocalbranch");
-    assertThat(detachedHeadSha1).isEqualTo(jGitProvider.determineBranchName(env));
-  }
-  
   @Test
   public void loadShortDescribe() {
     assertShortDescribe("1.0.2-12-g19471", "1.0.2-12");
@@ -315,16 +75,6 @@ public class GitCommitIdMojoTest {
 
     File result = commitIdMojo.craftPropertiesOutputFile(baseDir, generateGitPropertiesFilename);
     assertThat(result.getCanonicalPath()).isEqualTo(generateGitPropertiesFilename);
-  }
-
-  @Test
-  public void shouldPerformReplacements() throws MojoExecutionException {
-    mojo.propertiesReplacer = mock(PropertiesReplacer.class);
-    mojo.replacementProperties = mock(List.class);
-
-    mojo.execute();
-
-    verify(mojo.propertiesReplacer).performReplacement(any(Properties.class), eq(mojo.replacementProperties));
   }
 
   @Test

--- a/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitIntegrationTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public abstract class GitIntegrationTest {
 
   private static final String SANDBOX_DIR = "target" + File.separator + "sandbox" + File.separator;
+  protected static final String evaluateOnCommit = "HEAD";
 
   /**
    * Sandbox directory with unique name for current test.
@@ -105,6 +106,7 @@ public abstract class GitIntegrationTest {
     mojo.setFailOnNoGitDirectory(true);
     mojo.setUseNativeGit(false);
     mojo.setCommitIdGenerationMode("full");
+    mojo.setEvaluateOnCommit(evaluateOnCommit);
   }
 
   public void setProjectToExecuteMojoIn(@NotNull MavenProject project) {


### PR DESCRIPTION
This is a combined merge request for the following:
- #337: Create an Issue Template 
- #338: add an option to specify branch/tag/commit used when finding 'HEAD'
- add maven 3.5.2 to travis integrations tests 
- move (integration) tests from GitCommitIdMojoTest to GitCommitIdMojoIntegrationTest
- #339: git.tags yields wrong results for JGit 