### PR TITLE
#352 / #345 : add total commit count property via 'rev-list <commit> --count'

### DIFF
--- a/src/main/java/pl/project13/maven/git/GitCommitPropertyConstant.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitPropertyConstant.java
@@ -24,5 +24,6 @@ public class GitCommitPropertyConstant {
   public static final String TAGS = "tags";
   public static final String CLOSEST_TAG_NAME = "closest.tag.name";
   public static final String CLOSEST_TAG_COMMIT_COUNT = "closest.tag.commit.count";
+  public static final String TOTAL_COMMIT_COUNT = "total.commit.count";
 
 }

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -137,6 +137,8 @@ public abstract class GitDataProvider implements GitProvider {
       
       put(properties,GitCommitPropertyConstant.CLOSEST_TAG_NAME, getClosestTagName());
       put(properties,GitCommitPropertyConstant.CLOSEST_TAG_COMMIT_COUNT, getClosestTagCommitCount());
+
+      put(properties,GitCommitPropertyConstant.TOTAL_COMMIT_COUNT, getTotalCommitCount());
     } finally {
       finalCleanUp();
     }

--- a/src/main/java/pl/project13/maven/git/GitProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitProvider.java
@@ -37,6 +37,8 @@ public interface GitProvider {
 
   public String getClosestTagCommitCount() throws GitCommitIdExecutionException;
 
+  public String getTotalCommitCount() throws GitCommitIdExecutionException;
+
   public void finalCleanUp() throws GitCommitIdExecutionException;
 
 }

--- a/src/main/java/pl/project13/maven/git/JGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/JGitProvider.java
@@ -29,6 +29,7 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.RevWalkUtils;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.jetbrains.annotations.NotNull;
 
@@ -206,6 +207,16 @@ public class JGitProvider extends GitDataProvider {
     Repository repo = getGitRepository();
     try {
       return jGitCommon.getClosestTagCommitCount(evaluateOnCommit, repo, gitDescribe);
+    } catch (Throwable t) {
+      // could not find any tags to describe
+    }
+    return "";
+  }
+
+  @Override
+  public String getTotalCommitCount() throws GitCommitIdExecutionException {
+    try {
+      return String.valueOf(RevWalkUtils.count(revWalk, evalCommit, null));
     } catch (Throwable t) {
       // could not find any tags to describe
     }

--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -266,6 +266,11 @@ public class NativeGitProvider extends GitDataProvider {
   }
 
   @Override
+  public String getTotalCommitCount() throws GitCommitIdExecutionException {
+    return runQuietGitCommand(canonical, "rev-list " + evaluateOnCommit + " --count");
+  }
+
+  @Override
   public void finalCleanUp() throws GitCommitIdExecutionException {
   }
 

--- a/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
+++ b/src/test/java/pl/project13/maven/git/GitCommitIdMojoIntegrationTest.java
@@ -888,6 +888,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
 
     assertThat(Splitter.on(",").split(properties.get("git.tags").toString()))
       .containsOnly("lightweight-tag", "newest-tag");
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.total.commit.count", "2");
   }
 
   @Test
@@ -921,6 +922,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
 
     assertThat(Splitter.on(",").split(properties.get("git.tags").toString()))
       .containsOnly("annotated-tag", "lightweight-tag", "newest-tag");
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.total.commit.count", "1");
   }
 
   @Test
@@ -990,6 +992,7 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
       assertThat(targetProject.getProperties().stringPropertyNames()).contains("git.commit.id.full");
       assertThat(targetProject.getProperties().get("git.commit.id.full")).isNotEqualTo(commitIdOfMatchNeedle);
       assertThat(targetProject.getProperties().get("git.commit.id.full")).isEqualTo(headCommitId);
+      assertPropertyPresentAndEqual(targetProject.getProperties(), "git.total.commit.count", "3");
     }
   }
 
@@ -1229,6 +1232,8 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.closest.tag.name", "annotated-tag");
 
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.closest.tag.commit.count", "2");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.total.commit.count", "3");
   }
 
   @Test
@@ -1385,6 +1390,8 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.tags", "test_tag");
 
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.dirty", "true");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.total.commit.count", "2");
   }
 
   @Test
@@ -1416,6 +1423,8 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.tags", "test_tag");
 
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.dirty", "true");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.total.commit.count", "2");
   }
 
   @Test
@@ -1447,6 +1456,8 @@ public class GitCommitIdMojoIntegrationTest extends GitIntegrationTest {
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.tags", "test_tag");
 
     assertPropertyPresentAndEqual(targetProject.getProperties(), "git.dirty", "true");
+
+    assertPropertyPresentAndEqual(targetProject.getProperties(), "git.total.commit.count", "2");
   }
 
   // TODO: Test that fails when trying to pass invalid data to evaluateOnCommit

--- a/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
+++ b/src/test/java/pl/project13/maven/git/NativeAndJGitProviderTest.java
@@ -43,6 +43,7 @@ public class NativeAndJGitProviderTest extends GitIntegrationTest {
     "git.commit.message.full",
     "git.commit.message.short",
     "git.commit.time",
+    "git.total.commit.count",
     "git.remote.origin.url"
   };
 

--- a/src/test/resources/checks/checkstyle-suppressions.xml
+++ b/src/test/resources/checks/checkstyle-suppressions.xml
@@ -23,6 +23,6 @@
   <suppress checks="OverloadMethodsDeclarationOrder" files=".*\.java" />
   <suppress checks="VariableDeclarationUsageDistance" files=".*\.java" />
 
-  <suppress checks="AbbreviationAsWordInName" files="NativeAndJGitProviderTest\.java" lines="89"/>
+  <suppress checks="AbbreviationAsWordInName" files="NativeAndJGitProviderTest\.java" lines="90"/>
 
 </suppressions>


### PR DESCRIPTION
refs:
- https://github.com/ktoso/maven-git-commit-id-plugin/issues/352
- https://github.com/ktoso/maven-git-commit-id-plugin/pull/345