### PR TITLE
Read the output of native git before waiting for it to complete

### DIFF
--- a/src/main/java/pl/project13/maven/git/NativeGitProvider.java
+++ b/src/main/java/pl/project13/maven/git/NativeGitProvider.java
@@ -400,7 +400,6 @@ public class NativeGitProvider extends GitDataProvider {
       try {
         ProcessBuilder builder = new ProcessBuilder(command.split("\\s"));
         final Process proc = builder.directory(directory).start();
-        proc.waitFor();
         final InputStream is = proc.getInputStream();
         final InputStream err = proc.getErrorStream();
 
@@ -411,8 +410,9 @@ public class NativeGitProvider extends GitDataProvider {
           commandResult.append(line).append("\n");
         }
 
+        final StringBuilder errMsg = readStderr(err);
+        proc.waitFor();
         if (proc.exitValue() != 0) {
-          final StringBuilder errMsg = readStderr(err);
           throw new NativeCommandException(proc.exitValue(), command, directory, output, errMsg.toString());
         }
         output = commandResult.toString();
@@ -442,7 +442,6 @@ public class NativeGitProvider extends GitDataProvider {
         // so use the same protocol as used in the run() method
         ProcessBuilder builder = new ProcessBuilder(command.split("\\s"));
         final Process proc = builder.directory(directory).start();
-        proc.waitFor();
         final InputStream is = proc.getInputStream();
         final InputStream err = proc.getErrorStream();
         BufferedReader reader = new BufferedReader(new InputStreamReader(is));
@@ -451,8 +450,9 @@ public class NativeGitProvider extends GitDataProvider {
           empty = false;
         }
 
+        final StringBuilder errMsg = readStderr(err);
+        proc.waitFor();
         if (proc.exitValue() != 0) {
-          final StringBuilder errMsg = readStderr(err);
           throw new NativeCommandException(proc.exitValue(), command, directory, "", errMsg.toString());
         }
 


### PR DESCRIPTION
The current NativeGitProvider waits for the git process to be finished before it starts reading the output. This can cause a deadlock on some systems where the buffer size is smaller than the git output, for example when there are a lot of git tags.

Here is the documentation of [Process](https://docs.oracle.com/javase/7/docs/api/java/lang/Process.html) for reference:
> The parent process uses these streams to feed input to and get output from the subprocess. Because some native platforms only provide limited buffer size for standard input and output streams, failure to promptly write the input stream or read the output stream of the subprocess may cause the subprocess to block, or even deadlock.
