### PR TITLE
#379: Add tests for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ stages:
   - Integration Test
 
 jdk:
+  - oraclejdk11
   - oraclejdk10
   - oraclejdk9
   - oraclejdk8


### PR DESCRIPTION
the current version seems to already work with java 11
https://travis-ci.org/TheSnoozer/maven-git-commit-id-plugin/jobs/421822610

```
java version "11" 2018-09-25
Java(TM) SE Runtime Environment 18.9 (build 11+28)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11+28, mixed mode)
```
i would say that should be sufficient to say the current version supports java 11. I can remember that java 9 caused more headaches with incompatible plugins....