### PR TITLE
run on eclipse incremental build if properties file was not generated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
       <artifactId>maven-core</artifactId>
       <version>${maven-plugin-api.version}</version>
     </dependency>
+    <dependency>
+     <groupId>org.sonatype.plexus</groupId>
+     <artifactId>plexus-build-api</artifactId>
+     <version>0.0.7</version>
+    </dependency>
     <!-- dependencies to annotations -->
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -8,7 +8,7 @@
 			</pluginExecutionFilter>
 			<action>
 				<execute>
-					<runOnIncremental>false</runOnIncremental>
+					<runOnIncremental>true</runOnIncremental>
 					<runOnConfiguration>false</runOnConfiguration>
 				</execute>
 			</action>


### PR DESCRIPTION
This may fix issue #366 while still respecting performance concerns from #269.

It use a BuildContext as described in [m2e](https://www.eclipse.org/m2e/documentation/m2e-making-maven-plugins-compat.html#buildcontext) to distinguish between incremental and normal (e.g. mvn command line) builds. On incremental builds it should only run if the git.properties file is missing at all.

Additional the BuildContext can inform eclipse about the new generated file. (especially useful if file is generated in some folder not ignored by the IDE)