### PR TITLE
Support jgit 5.1.1, add direct httpclient, and update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
     <maven-plugin-api.version>3.0</maven-plugin-api.version>
     <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
 
-    <junit.version>5.2.0</junit.version>
     <mockito.version>2.21.0</mockito.version>
     <jgit.version>5.1.1.201809181055-r</jgit.version>
+    <junit.version>5.3.1</junit.version>
 
     <fest-assert.version>1.4</fest-assert.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.6</version>
+      <version>2.9.7</version>
     </dependency>
 
     <!-- Joda Time -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
     <maven-plugin-api.version>3.0</maven-plugin-api.version>
     <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
 
-    <jgit.version>5.0.2.201807311906-r</jgit.version>
     <junit.version>5.2.0</junit.version>
     <mockito.version>2.21.0</mockito.version>
+    <jgit.version>5.1.1.201809181055-r</jgit.version>
 
     <fest-assert.version>1.4</fest-assert.version>
   </properties>
@@ -103,6 +103,13 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>26.0-jre</version>
+    </dependency>
+
+    <!-- HttpClient -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.6</version>
     </dependency>
 
     <!-- JGit -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
     <maven-plugin-api.version>3.0</maven-plugin-api.version>
     <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
 
-    <mockito.version>2.21.0</mockito.version>
     <jgit.version>5.1.1.201809181055-r</jgit.version>
     <junit.version>5.3.1</junit.version>
+    <mockito.version>2.22.0</mockito.version>
 
     <fest-assert.version>1.4</fest-assert.version>
   </properties>


### PR DESCRIPTION
### Context

Support jgit 5.1.1 release.  Currently this plugin is using httpclient which was a transient dependency of jgit.  That transient is no longer present.  Therefore, for continued usage, a simple change to include the httpclient along with jgit 5.1.1 works without issue.  Additionally updated mockito/junit/jackson to latest releases.  All changes isolated to pom only.

### Contributor Checklist
- [ N/A] Added relevant integration or unit tests to verify the changes
- [ N/A] Update the Readme or any other documentation (including relevant Javadoc)
- [ X] Ensured that tests pass locally: `mvn clean package`
- [ N/A] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
