### PR TITLE
fixes #387 'runOnlyOnce' & --project make Mojo not run at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,8 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                     <!--
                        Use with caution!
 
-                       In a multi-module build, only run once. This means that the plugins effects will only execute once, for the parent project.
+                       In a multi-module build, only run once. This means that the plugins effects will only execute once, even if the
+                       parent projet is not in the reactor (when you use Maven's --project option or --resume-from ).
                        This probably won't "do the right thing" if your project has more than one git repository.
 
                        Important: If you're using `generateGitPropertiesFile`, setting `runOnlyOnce` will make the plugin

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -63,7 +63,10 @@ import javax.annotation.Nullable;
  */
 @Mojo(name = "revision", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
 public class GitCommitIdMojo extends AbstractMojo {
-  /**
+  /** if a user property exists with this name and {@link #runOnlyOnce} is true, it means this Mojo has already run */
+  private static final String GIT_COMMITID_MOJO_RUN_ONLY_ONCE_DONE = "GIT_COMMITID_MOJO_RUN_ONLY_ONCE_DONE";
+
+/**
    * The Maven Project.
    */
   @Parameter(defaultValue = "${project}", readonly = true, required = true)
@@ -378,9 +381,12 @@ public class GitCommitIdMojo extends AbstractMojo {
       }
 
       if (runOnlyOnce) {
-        if (!session.getExecutionRootDirectory().equals(session.getCurrentProject().getBasedir().getAbsolutePath())) {
-          log.info("runOnlyOnce is enabled and this project is not the top level project, skipping execution!");
+        Properties userProperties = session.getUserProperties();
+		if (userProperties.get(GIT_COMMITID_MOJO_RUN_ONLY_ONCE_DONE) != null) {
+          log.info("runOnlyOnce is enabled and " + this.getClass().getSimpleName() + " has already run, skipping execution!");
           return;
+        } else {
+        	userProperties.put(GIT_COMMITID_MOJO_RUN_ONLY_ONCE_DONE, "1");        	
         }
       }
 


### PR DESCRIPTION
This commit fixes
https://github.com/ktoso/maven-git-commit-id-plugin/issues/387

### Context
<!--- Thank you for your contribution to this project! :-) -->
<!--- Please tell us a bit more what do you indent with your change and how users of the plugin will benefit from it. -->
<!--- If applicable also provide a link to any relevant issue. -->

### Contributor Checklist
- [ ] Added relevant integration or unit tests to verify the changes
- [ ] Update the Readme or any other documentation (including relevant Javadoc)
- [ ] Ensured that tests pass locally: `mvn clean package`
- [ ] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
