### PR TITLE
Issue #24 Add property for using CI branch name or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,16 @@ It's really simple to setup this plugin; below is a sample pom that you may base
                         If you have a specific use-case that is currently not white listed feel free to file an issue.
                     -->
                     <evaluateOnCommit>HEAD</evaluateOnCommit>
+                    
+                    
+                    <!-- @since 3.0.0 -->
+                    <!--
+                        Use branch name from build environment. Set to {@code 'false'} to use JGit/GIT to get current branch name.
+                        Useful when using the JGitflow maven plugin.
+                        Note: If not using "Check out to specific local branch' and setting this to false may result in getting
+                        detached head state and therefore a commit id as branch name.
+                    -->
+                    <useBranchNameFromBuildEnvironment>false</useBranchNameFromBuildEnvironment>
                 </configuration>
 
             </plugin>
@@ -949,7 +959,7 @@ Worth pointing out is, that git-commit-id tries to be 1-to-1 compatible with git
 * **long** - `(default: false)` git-describe, by default, returns just the tag name, if the current commit is tagged. Use this option to force it to format the output using the typical describe format. An example would be: `tagname-0-gc0ffebabe` - notice that the distance from the tag is 0 here, if you don't use **forceLongFormat** mode, the describe for such commit would look like this: `tagname`.
 * **always** - `(default: true)` if unable to find a tag, print out just the object id of the current commit. Useful when you always want to return something meaningful in the describe property.
 * **skip** - `(default: false)` when you don't use `git-describe` information in your build, you can opt to be calculate it.
-
+* **useBranchNameFromBuildEnvironment** - `(default: true)` use branch name from build environment
 
 **validationProperties** Since version **2.2.2** the maven-git-commit-id-plugin comes equipped with an additional validation utility which can be used to verify if your project properties are set as you would like to have them set. This feature ships with an additional mojo execution and for instance allows to check if the version is not a snapshot build. If you are interested in the config checkout the[validation utility documentation](https://github.com/ktoso/maven-git-commit-id-plugin#validate-if-properties-are-set-as-expected).
 

--- a/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
+++ b/src/main/java/pl/project13/maven/git/GitCommitIdMojo.java
@@ -326,6 +326,15 @@ public class GitCommitIdMojo extends AbstractMojo {
   long nativeGitTimeoutInMs;
   
   /**
+   * Use branch name from build environment. Set to {@code 'false'} to use JGit/GIT to get current branch name.
+   * Useful when using the JGitflow maven plugin.
+   * Note: If not using "Check out to specific local branch' and setting this to false may result in getting
+   * detached head state and therefore a commit id as branch name.
+   */
+  @Parameter(defaultValue = "true")
+  boolean useBranchNameFromBuildEnvironment;
+  
+  /**
    * Injected {@link BuildContext} to recognize incremental builds.
    */
   @Component
@@ -522,7 +531,8 @@ public class GitCommitIdMojo extends AbstractMojo {
               .setDateFormat(dateFormat)
               .setDateFormatTimeZone(dateFormatTimeZone)
               .setGitDescribe(gitDescribe)
-              .setCommitIdGenerationMode(commitIdGenerationModeEnum);
+              .setCommitIdGenerationMode(commitIdGenerationModeEnum)
+              .setUseBranchNameFromBuildEnvironment(useBranchNameFromBuildEnvironment);
 
       nativeGitProvider.loadGitData(evaluateOnCommit, properties);
     } catch (IOException e) {
@@ -538,7 +548,8 @@ public class GitCommitIdMojo extends AbstractMojo {
         .setDateFormat(dateFormat)
         .setDateFormatTimeZone(dateFormatTimeZone)
         .setGitDescribe(gitDescribe)
-        .setCommitIdGenerationMode(commitIdGenerationModeEnum);
+        .setCommitIdGenerationMode(commitIdGenerationModeEnum)
+        .setUseBranchNameFromBuildEnvironment(useBranchNameFromBuildEnvironment);
 
     jGitProvider.loadGitData(evaluateOnCommit, properties);
   }

--- a/src/main/java/pl/project13/maven/git/GitDataProvider.java
+++ b/src/main/java/pl/project13/maven/git/GitDataProvider.java
@@ -52,6 +52,8 @@ public abstract class GitDataProvider implements GitProvider {
   protected CommitIdGenerationMode commitIdGenerationMode;
 
   protected String evaluateOnCommit;
+  
+  protected boolean useBranchNameFromBuildEnvironment;
 
   public GitDataProvider(@Nonnull LoggerBridge log) {
     this.log = log;
@@ -84,6 +86,11 @@ public abstract class GitDataProvider implements GitProvider {
 
   public GitDataProvider setDateFormatTimeZone(String dateFormatTimeZone) {
     this.dateFormatTimeZone = dateFormatTimeZone;
+    return this;
+  }
+  
+  public GitDataProvider setUseBranchNameFromBuildEnvironment(boolean useBranchNameFromBuildEnvironment) {
+    this.useBranchNameFromBuildEnvironment = useBranchNameFromBuildEnvironment;
     return this;
   }
 
@@ -193,7 +200,7 @@ public abstract class GitDataProvider implements GitProvider {
    */
   protected String determineBranchName(@Nonnull Map<String, String> env) throws GitCommitIdExecutionException {
     BuildServerDataProvider buildServerDataProvider = BuildServerDataProvider.getBuildServerProvider(env,log);
-    if (!(buildServerDataProvider instanceof UnknownBuildServerData)) {
+    if (useBranchNameFromBuildEnvironment && !(buildServerDataProvider instanceof UnknownBuildServerData)) {
       String branchName = buildServerDataProvider.getBuildBranch();
       if (isNullOrEmpty(branchName)) {
         log.info("Detected that running on CI environment, but using repository branch, no GIT_BRANCH detected.");


### PR DESCRIPTION
### Context
Added property for setting if branch name should be taken from build environment or not.
When using JGitflow maven plugin, then the property from Jenkins can not be used, so this will
open up for use with that plugin. The property will be true by default, so that old behavior is used.

### Contributor Checklist
- [X] Added relevant integration or unit tests to verify the changes
- [X] Update the Readme or any other documentation (including relevant Javadoc)
- [Could not run with maven, but executed in Eclipse] Ensured that tests pass locally: `mvn clean package`
- [X] Ensured that the code meets the current `checkstyle` coding style definition: `mvn clean verify -Pcheckstyle -Dmaven.test.skip=true -B`
